### PR TITLE
[FYST-2125] Utilize payload configurations in tax-benefits-backend deploy

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -57,10 +57,10 @@ jobs:
       - name: Setup OpenTofu
         uses: opentofu/setup-opentofu@v1
       - name: Initialize OpenTofu
-        working-directory: ./tofu/config/${{ env.config }}
+        working-directory: ./tofu/config/${{ env.CONFIG }}
         run: tofu init
       # TODO: Add a manual approval step here. For now, we'll use GitHub
       # Actions' environment protection feature for sensitive environments.
       - name: Apply changes
-        working-directory: ./tofu/config/${{ env.config }}
+        working-directory: ./tofu/config/${{ env.CONFIG }}
         run: tofu apply --auto-approve


### PR DESCRIPTION
We need to pass in the payload from the `pya` `.deploy-to-staging.yaml` workflow 