### PR TITLE
[FYST-2125] Use secrets module to store secret_key_base

### DIFF
--- a/tofu/config/staging.pya.fileyourstatetaxes.org/main.tf
+++ b/tofu/config/staging.pya.fileyourstatetaxes.org/main.tf
@@ -41,8 +41,11 @@ module "secrets" {
   environment = "staging"
 
   secrets = {
-    secret_key_base = {
-     description = "Rails secret_key_base"
+    "rails_secret_key_base" = {
+      description = "secret_key_base for Rails app"
+      start_value = jsonencode({
+        key = ""
+      })
     }
   }
 }
@@ -89,9 +92,13 @@ module "web" {
   create_repository	= true
   create_version_parameter = true
   public = true
+  health_check_path = "/up"
 
   environment_variables = {
     RACK_ENV = "staging"
+  }
+  environment_secrets = {
+    SECRET_KEY_BASE = "${module.secrets.secrets["rails_secret_key_base"].secret_arn}:key"
   }
 }
 


### PR DESCRIPTION
Saw errors:
- `ArgumentError: Missing `secret_key_base` for 'production' environment, set this string with `bin/rails credentials:edit` (ArgumentError)`
- `raise ArgumentError, "Missing `secret_key_base` for '#{Rails.env}' environment, set this string with `bin/rails credentials:edit`"`
in the task logs https://us-east-1.console.aws.amazon.com/ecs/v2/clusters/pya-staging-web/tasks/a70dd3e6d84e4560b76b7640f848104b/logs?region=us-east-1

A few points of interest:
[ECS Clusters](https://300423309117-ti7bftmc.us-east-1.console.aws.amazon.com/ecs/v2/clusters?region=us-east-1): This is where the individual clusters can be found. We create one per service (in this case, worker and web)
[pya-staging-web](https://300423309117-ti7bftmc.us-east-1.console.aws.amazon.com/ecs/v2/clusters/pya-staging-web/services?region=us-east-1): If you click into the cluster (web in this case) you can see the services and tasks running on it

What was done:
- Use secrets module to instantiate an empty store for the `secret_key_base`
- Fill in the `secret_key_base` in Secrets Manager in AWS
- Saw that we were failing health checks, so updated configuration to `health_check_path = "/up"` (this is for rails apps)