### PR TITLE
Add READMEs to staging.pya folder + the shared pya module

### DIFF
--- a/tofu/config/staging.pya.fileyourstatetaxes.org/README.md
+++ b/tofu/config/staging.pya.fileyourstatetaxes.org/README.md
@@ -2,6 +2,15 @@
 
 This configures and manages the tofu (or terraform) backend for [Prior Year Access (PYA)](https://github.com/codeforamerica/pya) staging environment
 
+We utilize several [tofu modules](https://github.com/codeforamerica/tofu-modules?tab=readme-ov-file)
+- [AWS Backend](https://github.com/codeforamerica/tofu-modules-aws-backend)
+- In [PYA module](https://github.com/codeforamerica/tax-benefits-backend/tree/main/tofu/modules/pya)
+  - [AWS Fargate Service Module](https://github.com/codeforamerica/tofu-modules-aws-fargate-service)
+  - [AWS VPC Module](https://github.com/codeforamerica/tofu-modules-aws-vpc)
+  - [AWS Secrets Module](https://github.com/codeforamerica/tofu-modules-aws-secrets)
+  - [AWS Serverless DB Module](https://github.com/codeforamerica/tofu-modules-aws-serverless-database)
+  - [AWS Logging Module](https://github.com/codeforamerica/tofu-modules-aws-logging)
+
 ## Running
 
 You may need to set up OpenTofu and set up your `AWS_PROFILE` in order to run `tofu init` and `tofu plan`.

--- a/tofu/modules/pya/README.md
+++ b/tofu/modules/pya/README.md
@@ -29,6 +29,9 @@ module "pya" {
 }
 ```
 
+Make sure you are in the correct `/config` folder before running any tofu commands
+with the correct `AWS_PROFILE` set in your shell (`.zshrc`, `.bash_profile`, etc).
+
 Make sure you run `tofu init` after adding the module to your configuration,
 then plan your configuration to see the changes that would be applied:
 


### PR DESCRIPTION
If you want to see them with markdown format applied:
- https://github.com/codeforamerica/tax-benefits-backend/tree/add-read-me/tofu/modules/pya
- https://github.com/codeforamerica/tax-benefits-backend/blob/add-read-me/tofu/config/staging.pya.fileyourstatetaxes.org/README.md