### PR TITLE
[FYST-2134] Define ENV variables to be used in PYA

### DIFF
--- a/tofu/modules/pya/main.tf
+++ b/tofu/modules/pya/main.tf
@@ -69,7 +69,7 @@ module "web" {
 
   environment_variables = {
     RACK_ENV = var.environment
-    DATABASE_HOST = module.database.cluster_endpoint
+    DATABASE_URL = module.database.cluster_endpoint
   }
   environment_secrets = {
     DATABASE_PASSWORD      = "${module.database.secret_arn}:password"
@@ -98,7 +98,7 @@ module "workers" {
 
   environment_variables = {
     RACK_ENV = var.environment
-    DATABASE_HOST = module.database.cluster_endpoint
+    DATABASE_URL = module.database.cluster_endpoint
   }
   environment_secrets = {
     DATABASE_PASSWORD      = "${module.database.secret_arn}:password"


### PR DESCRIPTION
https://codeforamerica.atlassian.net/browse/FYST-2134
We need the ENV variables/secrets available so we can [connect to the correct db from our app/workers in pya](https://github.com/codeforamerica/pya/blob/main/config/database.yml). Currently it connects to sqlite which we dont even provision for this app. 

[gist for tofu plan output in **staging**](https://gist.github.com/arinchoi03/704348386f1f5fcc07e6a6717d2ca65d)

[gist for tofu plan output in **prod**](https://gist.github.com/arinchoi03/1d68bc47b1ee967863a27877e8ffaeb2)

<details>

<summary>staging output summary</summary>

```ruby
  # module.pya.module.web.aws_iam_policy.secrets will be updated in-place
  ~ resource "aws_iam_policy" "secrets" {
        id               = "arn:aws:iam::300423309117:policy/pya-staging-web-secrets-access-2025060217203363480000001c"
        name             = "pya-staging-web-secrets-access-2025060217203363480000001c"
      ~ policy           = jsonencode(
          ~ {
              ~ Statement = [
                  ~ {
                      ~ Resource = [
                            # (2 unchanged elements hidden)
                            "arn:aws:secretsmanager:us-east-1:300423309117:secret:pya/staging//rails_secret_key_base-20250610205228067300000001-HxBP0A",
                          + "arn:aws:secretsmanager:us-east-1:300423309117:secret:rds!cluster-1c174606-0fc5-4409-aeed-714d5dde390b-Mlp93d",
                        ]
                        # (2 unchanged attributes hidden)
                    },
                ]
                # (1 unchanged attribute hidden)
            }
        )
        tags             = {}
        # (7 unchanged attributes hidden)
    }

  # module.pya.module.workers.aws_iam_policy.secrets will be updated in-place
  ~ resource "aws_iam_policy" "secrets" {
        id               = "arn:aws:iam::300423309117:policy/pya-staging-worker-secrets-access-20250602174730998000000004"
        name             = "pya-staging-worker-secrets-access-20250602174730998000000004"
      ~ policy           = jsonencode(
          ~ {
              ~ Statement = [
                  ~ {
                      ~ Resource = [
                            # (1 unchanged element hidden)
                            "arn:aws:ssm:us-east-1:300423309117:parameter/pya/staging/worker/otel",
                          + "arn:aws:secretsmanager:us-east-1:300423309117:secret:rds!cluster-1c174606-0fc5-4409-aeed-714d5dde390b-Mlp93d",
                        ]
                        # (2 unchanged attributes hidden)
                    },
                ]
                # (1 unchanged attribute hidden)
            }
        )
        tags             = {}
        # (7 unchanged attributes hidden)
    }

  # module.pya.module.web.module.ecs_service.module.fargate.aws_ecs_service.main[0] will be updated in-place
  ~ resource "aws_ecs_service" "main" {
        id                                 = "arn:aws:ecs:us-east-1:300423309117:service/pya-staging-web/pya-staging-web"
        name                               = "pya-staging-web"
        tags                               = {}
      ~ task_definition                    = "arn:aws:ecs:us-east-1:300423309117:task-definition/pya-staging-web:14" -> (known after apply)
        # (16 unchanged attributes hidden)

        # (4 unchanged blocks hidden)
    }

  # module.pya.module.workers.module.ecs_service.module.fargate.aws_ecs_service.main[0] will be updated in-place
  ~ resource "aws_ecs_service" "main" {
        id                                 = "arn:aws:ecs:us-east-1:300423309117:service/pya-staging-worker/pya-staging-worker"
        name                               = "pya-staging-worker"
        tags                               = {}
      ~ task_definition                    = "arn:aws:ecs:us-east-1:300423309117:task-definition/pya-staging-worker:14" -> (known after apply)
        # (16 unchanged attributes hidden)

        # (3 unchanged blocks hidden)
    }

  # module.pya.module.web.module.ecs_service.module.fargate.module.task.aws_ecs_task_definition.main[0] must be replaced
+/- resource "aws_ecs_task_definition" "main" {
      ~ arn                      = "arn:aws:ecs:us-east-1:300423309117:task-definition/pya-staging-web:14" -> (known after apply)
      ~ arn_without_revision     = "arn:aws:ecs:us-east-1:300423309117:task-definition/pya-staging-web" -> (known after apply)
      ~ container_definitions    = jsonencode(
          ~ [
              ~ {
                  - mountPoints      = []
                    name             = "otel-collector"
                  - portMappings     = []
                  - systemControls   = []
                  - volumesFrom      = []
                    # (8 unchanged attributes hidden)
                },
              ~ {
                  ~ environment       = [
                      + {
                          + name  = "DATABASE_URL"
                          + value = "pya-staging-web.cluster-ckh4cgkekf60.us-east-1.rds.amazonaws.com"
                        },
                        {
                            name  = "RACK_ENV"
                            value = "staging"
                        },
                    ]
                  - mountPoints       = []
                    name              = "pya-staging-web"
                  ~ portMappings      = [
                      ~ {
                          - hostPort      = 3000
                          - protocol      = "tcp"
                            # (1 unchanged attribute hidden)
                        },
                    ]
                  ~ secrets           = [
                      + {
                          + name      = "DATABASE_PASSWORD"
                          + valueFrom = "arn:aws:secretsmanager:us-east-1:300423309117:secret:rds!cluster-1c174606-0fc5-4409-aeed-714d5dde390b-Mlp93d:password::"
                        },
                      + {
                          + name      = "DATABASE_USER"
                          + valueFrom = "arn:aws:secretsmanager:us-east-1:300423309117:secret:rds!cluster-1c174606-0fc5-4409-aeed-714d5dde390b-Mlp93d:username::"
                        },
                        {
                            name      = "SECRET_KEY_BASE"
                            valueFrom = "arn:aws:secretsmanager:us-east-1:300423309117:secret:pya/staging//rails_secret_key_base-20250610205228067300000001-HxBP0A:key::"
                        },
                    ]
                  - systemControls    = []
                  - volumesFrom       = []
                    # (7 unchanged attributes hidden)
                },
            ] # forces replacement
        )
      ~ enable_fault_injection   = false -> (known after apply)
      ~ id                       = "pya-staging-web" -> (known after apply)
      ~ revision                 = 14 -> (known after apply)
      - tags                     = {} -> null
        # (10 unchanged attributes hidden)
    }

  # module.pya.module.workers.module.ecs_service.module.fargate.module.task.aws_ecs_task_definition.main[0] must be replaced
+/- resource "aws_ecs_task_definition" "main" {
      ~ arn                      = "arn:aws:ecs:us-east-1:300423309117:task-definition/pya-staging-worker:14" -> (known after apply)
      ~ arn_without_revision     = "arn:aws:ecs:us-east-1:300423309117:task-definition/pya-staging-worker" -> (known after apply)
      ~ container_definitions    = jsonencode(
          ~ [
              ~ {
                  - mountPoints      = []
                    name             = "otel-collector"
                  - portMappings     = []
                  - systemControls   = []
                  - volumesFrom      = []
                    # (8 unchanged attributes hidden)
                },
              ~ {
                  ~ environment       = [
                      + {
                          + name  = "DATABASE_URL"
                          + value = "pya-staging-web.cluster-ckh4cgkekf60.us-east-1.rds.amazonaws.com"
                        },
                        {
                            name  = "RACK_ENV"
                            value = "staging"
                        },
                    ]
                  - mountPoints       = []
                    name              = "pya-staging-worker"
                  ~ portMappings      = [
                      ~ {
                          - hostPort      = 3000
                          - protocol      = "tcp"
                            # (1 unchanged attribute hidden)
                        },
                    ]
                  + secrets           = [
                      + {
                          + name      = "DATABASE_PASSWORD"
                          + valueFrom = "arn:aws:secretsmanager:us-east-1:300423309117:secret:rds!cluster-1c174606-0fc5-4409-aeed-714d5dde390b-Mlp93d:password::"
                        },
                      + {
                          + name      = "DATABASE_USER"
                          + valueFrom = "arn:aws:secretsmanager:us-east-1:300423309117:secret:rds!cluster-1c174606-0fc5-4409-aeed-714d5dde390b-Mlp93d:username::"
                        },
                    ]
                  - systemControls    = []
                  - volumesFrom       = []
                    # (7 unchanged attributes hidden)
                },
            ] # forces replacement
        )
      ~ enable_fault_injection   = false -> (known after apply)
      ~ id                       = "pya-staging-worker" -> (known after apply)
      ~ revision                 = 14 -> (known after apply)
      - tags                     = {} -> null
        # (10 unchanged attributes hidden)
    }

Plan: 2 to add, 4 to change, 2 to destroy.
```
</p>
</details> 

<details>
<summary>prod output summary</summary>

```ruby
  # module.pya.module.web.aws_iam_policy.secrets will be updated in-place
  ~ resource "aws_iam_policy" "secrets" {
        id               = "arn:aws:iam::828007041297:policy/pya-production-web-secrets-access-2025061319391678530000001f"
        name             = "pya-production-web-secrets-access-2025061319391678530000001f"
      ~ policy           = jsonencode(
          ~ {
              ~ Statement = [
                  ~ {
                      ~ Resource = [
                            # (2 unchanged elements hidden)
                            "arn:aws:secretsmanager:us-east-1:828007041297:secret:pya/production//rails_secret_key_base-2025061319374160900000000e-XjDKE1",
                          + "arn:aws:secretsmanager:us-east-1:828007041297:secret:rds!cluster-e67cc6a9-7be0-4cfd-82bc-d52797fc614e-ToyDM6",
                        ]
                        # (2 unchanged attributes hidden)
                    },
                ]
                # (1 unchanged attribute hidden)
            }
        )
        tags             = {}
        # (7 unchanged attributes hidden)
    }

  # module.pya.module.workers.aws_iam_policy.secrets will be updated in-place
  ~ resource "aws_iam_policy" "secrets" {
        id               = "arn:aws:iam::828007041297:policy/pya-production-worker-secrets-access-20250613195823151700000003"
        name             = "pya-production-worker-secrets-access-20250613195823151700000003"
      ~ policy           = jsonencode(
          ~ {
              ~ Statement = [
                  ~ {
                      ~ Resource = [
                            # (1 unchanged element hidden)
                            "arn:aws:ssm:us-east-1:828007041297:parameter/pya/production/worker/otel",
                          + "arn:aws:secretsmanager:us-east-1:828007041297:secret:rds!cluster-e67cc6a9-7be0-4cfd-82bc-d52797fc614e-ToyDM6",
                        ]
                        # (2 unchanged attributes hidden)
                    },
                ]
                # (1 unchanged attribute hidden)
            }
        )
        tags             = {}
        # (7 unchanged attributes hidden)
    }

  # module.pya.module.web.module.ecs_service.module.fargate.aws_ecs_service.main[0] will be updated in-place
  ~ resource "aws_ecs_service" "main" {
        id                                 = "arn:aws:ecs:us-east-1:828007041297:service/pya-production-web/pya-production-web"
        name                               = "pya-production-web"
        tags                               = {}
      ~ task_definition                    = "arn:aws:ecs:us-east-1:828007041297:task-definition/pya-production-web:1" -> (known after apply)
        # (16 unchanged attributes hidden)

        # (4 unchanged blocks hidden)
    }

  # module.pya.module.workers.module.ecs_service.module.fargate.aws_ecs_service.main[0] will be updated in-place
  ~ resource "aws_ecs_service" "main" {
        id                                 = "arn:aws:ecs:us-east-1:828007041297:service/pya-production-worker/pya-production-worker"
        name                               = "pya-production-worker"
        tags                               = {}
      ~ task_definition                    = "arn:aws:ecs:us-east-1:828007041297:task-definition/pya-production-worker:1" -> (known after apply)
        # (16 unchanged attributes hidden)

        # (3 unchanged blocks hidden)
    }

  # module.pya.module.web.module.ecs_service.module.fargate.module.task.aws_ecs_task_definition.main[0] must be replaced
+/- resource "aws_ecs_task_definition" "main" {
      ~ arn                      = "arn:aws:ecs:us-east-1:828007041297:task-definition/pya-production-web:1" -> (known after apply)
      ~ arn_without_revision     = "arn:aws:ecs:us-east-1:828007041297:task-definition/pya-production-web" -> (known after apply)
      ~ container_definitions    = jsonencode(
          ~ [
              ~ {
                  - mountPoints      = []
                    name             = "otel-collector"
                  - portMappings     = []
                  - systemControls   = []
                  - volumesFrom      = []
                    # (8 unchanged attributes hidden)
                },
              ~ {
                  ~ environment       = [
                      + {
                          + name  = "DATABASE_URL"
                          + value = "pya-production-web.cluster-csjcc2coc9nm.us-east-1.rds.amazonaws.com"
                        },
                        {
                            name  = "RACK_ENV"
                            value = "production"
                        },
                    ]
                  - mountPoints       = []
                    name              = "pya-production-web"
                  ~ portMappings      = [
                      ~ {
                          - hostPort      = 3000
                          - protocol      = "tcp"
                            # (1 unchanged attribute hidden)
                        },
                    ]
                  ~ secrets           = [
                      + {
                          + name      = "DATABASE_PASSWORD"
                          + valueFrom = "arn:aws:secretsmanager:us-east-1:828007041297:secret:rds!cluster-e67cc6a9-7be0-4cfd-82bc-d52797fc614e-ToyDM6:password::"
                        },
                      + {
                          + name      = "DATABASE_USER"
                          + valueFrom = "arn:aws:secretsmanager:us-east-1:828007041297:secret:rds!cluster-e67cc6a9-7be0-4cfd-82bc-d52797fc614e-ToyDM6:username::"
                        },
                        {
                            name      = "SECRET_KEY_BASE"
                            valueFrom = "arn:aws:secretsmanager:us-east-1:828007041297:secret:pya/production//rails_secret_key_base-2025061319374160900000000e-XjDKE1:key::"
                        },
                    ]
                  - systemControls    = []
                  - volumesFrom       = []
                    # (7 unchanged attributes hidden)
                },
            ] # forces replacement
        )
      ~ enable_fault_injection   = false -> (known after apply)
      ~ id                       = "pya-production-web" -> (known after apply)
      ~ revision                 = 1 -> (known after apply)
      - tags                     = {} -> null
        # (10 unchanged attributes hidden)
    }

  # module.pya.module.workers.module.ecs_service.module.fargate.module.task.aws_ecs_task_definition.main[0] must be replaced
+/- resource "aws_ecs_task_definition" "main" {
      ~ arn                      = "arn:aws:ecs:us-east-1:828007041297:task-definition/pya-production-worker:1" -> (known after apply)
      ~ arn_without_revision     = "arn:aws:ecs:us-east-1:828007041297:task-definition/pya-production-worker" -> (known after apply)
      ~ container_definitions    = jsonencode(
          ~ [
              ~ {
                  - mountPoints      = []
                    name             = "otel-collector"
                  - portMappings     = []
                  - systemControls   = []
                  - volumesFrom      = []
                    # (8 unchanged attributes hidden)
                },
              ~ {
                  ~ environment       = [
                      + {
                          + name  = "DATABASE_URL"
                          + value = "pya-production-web.cluster-csjcc2coc9nm.us-east-1.rds.amazonaws.com"
                        },
                        {
                            name  = "RACK_ENV"
                            value = "production"
                        },
                    ]
                  - mountPoints       = []
                    name              = "pya-production-worker"
                  ~ portMappings      = [
                      ~ {
                          - hostPort      = 3000
                          - protocol      = "tcp"
                            # (1 unchanged attribute hidden)
                        },
                    ]
                  + secrets           = [
                      + {
                          + name      = "DATABASE_PASSWORD"
                          + valueFrom = "arn:aws:secretsmanager:us-east-1:828007041297:secret:rds!cluster-e67cc6a9-7be0-4cfd-82bc-d52797fc614e-ToyDM6:password::"
                        },
                      + {
                          + name      = "DATABASE_USER"
                          + valueFrom = "arn:aws:secretsmanager:us-east-1:828007041297:secret:rds!cluster-e67cc6a9-7be0-4cfd-82bc-d52797fc614e-ToyDM6:username::"
                        },
                    ]
                  - systemControls    = []
                  - volumesFrom       = []
                    # (7 unchanged attributes hidden)
                },
            ] # forces replacement
        )
      ~ enable_fault_injection   = false -> (known after apply)
      ~ id                       = "pya-production-worker" -> (known after apply)
      ~ revision                 = 1 -> (known after apply)
      - tags                     = {} -> null
        # (10 unchanged attributes hidden)
    }

Plan: 2 to add, 4 to change, 2 to destroy.
```
</p>
</details> 