### PR TITLE
[FYST-2134] Name the cluster endpoint as the DATABASE_HOST not DATABASE_URL

### DIFF
--- a/tofu/modules/pya/main.tf
+++ b/tofu/modules/pya/main.tf
@@ -69,7 +69,7 @@ module "web" {
 
   environment_variables = {
     RACK_ENV = var.environment
-    DATABASE_URL = module.database.cluster_endpoint
+    DATABASE_HOST = module.database.cluster_endpoint
   }
   environment_secrets = {
     DATABASE_PASSWORD      = "${module.database.secret_arn}:password"


### PR DESCRIPTION
Based on[ examples in the docs](https://guides.rubyonrails.org/configuring.html#connection-preference) and[ this walkthrough](https://www.codewithjason.com/set-rds-database-rails-ec2/), it looks like what the `module.database.cluster_endpoint` is actually what the `DATABASE_HOST` expects. 

If `ENV["DATABASE_URL"]` is defined in the environment (which it currently is due to the opentofu config), it will override the `DATABASE_HOST` that we define:

> If you have both config/database.yml and ENV['DATABASE_URL'] set then Rails will merge the configuration together. To better understand this we must see some examples.

> When duplicate connection information is provided the environment variable will take precedence:

I'm going to remove the `DATABASE_URL` from the env and only define the HOST so we can access it from the `databse.yml` in pya.


### Change summary below:

<details>
<summary> prod changes </summary>

```ruby
  # module.pya.module.web.module.ecs_service.module.fargate.aws_ecs_service.main[0] will be updated in-place
  ~ resource "aws_ecs_service" "main" {
        id                                 = "arn:aws:ecs:us-east-1:828007041297:service/pya-production-web/pya-production-web"
        name                               = "pya-production-web"
        tags                               = {}
      ~ task_definition                    = "arn:aws:ecs:us-east-1:828007041297:task-definition/pya-production-web:2" -> (known after apply)
        # (16 unchanged attributes hidden)

        # (4 unchanged blocks hidden)
    }

  # module.pya.module.web.module.ecs_service.module.fargate.module.task.aws_ecs_task_definition.main[0] must be replaced
+/- resource "aws_ecs_task_definition" "main" {
      ~ arn                      = "arn:aws:ecs:us-east-1:828007041297:task-definition/pya-production-web:2" -> (known after apply)
      ~ arn_without_revision     = "arn:aws:ecs:us-east-1:828007041297:task-definition/pya-production-web" -> (known after apply)
      ~ container_definitions    = jsonencode(
          ~ [
              ~ {
                  - mountPoints      = []
                    name             = "otel-collector"
                  - portMappings     = []
                  - systemControls   = []
                  - volumesFrom      = []
                    # (8 unchanged attributes hidden)
                },
              ~ {
                  ~ environment       = [
                      ~ {
                          ~ name  = "DATABASE_URL" -> "DATABASE_HOST"
Name the cluster endpoint as the DATABASE_HOST not DATABASE_URL
                            # (1 unchanged attribute hidden)
                        },
                        {
                            name  = "RACK_ENV"
                            value = "production"
                        },
                    ]
                  - mountPoints       = []
                    name              = "pya-production-web"
                  ~ portMappings      = [
                      ~ {
                          - hostPort      = 3000
                          - protocol      = "tcp"
                            # (1 unchanged attribute hidden)
                        },
                    ]
                  - systemControls    = []
                  - volumesFrom       = []
                    # (8 unchanged attributes hidden)
                },
            ] # forces replacement
        )
      ~ enable_fault_injection   = false -> (known after apply)
      ~ id                       = "pya-production-web" -> (known after apply)
      ~ revision                 = 2 -> (known after apply)
      - tags                     = {} -> null
        # (10 unchanged attributes hidden)
    }

Plan: 1 to add, 1 to change, 1 to destroy.
```
</details>

-------------------------------------------


<details>
<summary>staging changes</summary>

```ruby

  # module.pya.module.web.module.ecs_service.module.fargate.aws_ecs_service.main[0] will be updated in-place
  ~ resource "aws_ecs_service" "main" {
        id                                 = "arn:aws:ecs:us-east-1:300423309117:service/pya-staging-web/pya-staging-web"
        name                               = "pya-staging-web"
        tags                               = {}
      ~ task_definition                    = "arn:aws:ecs:us-east-1:300423309117:task-definition/pya-staging-web:18" -> (known after apply)
        # (16 unchanged attributes hidden)

        # (4 unchanged blocks hidden)
    }

  # module.pya.module.web.module.ecs_service.module.fargate.module.task.aws_ecs_task_definition.main[0] must be replaced
+/- resource "aws_ecs_task_definition" "main" {
      ~ arn                      = "arn:aws:ecs:us-east-1:300423309117:task-definition/pya-staging-web:18" -> (known after apply)
      ~ arn_without_revision     = "arn:aws:ecs:us-east-1:300423309117:task-definition/pya-staging-web" -> (known after apply)
      ~ container_definitions    = jsonencode(
          ~ [
              ~ {
                  - mountPoints      = []
                    name             = "otel-collector"
                  - portMappings     = []
                  - systemControls   = []
                  - volumesFrom      = []
                    # (8 unchanged attributes hidden)
                },
              ~ {
                  ~ environment       = [
                      ~ {
                          ~ name  = "DATABASE_URL" -> "DATABASE_HOST"
                            # (1 unchanged attribute hidden)
                        },
                        {
                            name  = "RACK_ENV"
                            value = "staging"
                        },
                    ]
                  - mountPoints       = []
                    name              = "pya-staging-web"
                  ~ portMappings      = [
                      ~ {
                          - hostPort      = 3000
                          - protocol      = "tcp"
                            # (1 unchanged attribute hidden)
                        },
                    ]
                  - systemControls    = []
                  - volumesFrom       = []
                    # (8 unchanged attributes hidden)
                },
            ] # forces replacement
        )
      ~ enable_fault_injection   = false -> (known after apply)
      ~ id                       = "pya-staging-web" -> (known after apply)
      ~ revision                 = 18 -> (known after apply)
      - tags                     = {} -> null
        # (10 unchanged attributes hidden)
    }

Plan: 1 to add, 1 to change, 1 to destroy.
```
</details>