### PR TITLE
Add heroku pya to list of deployable configurations

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -23,6 +23,7 @@ on:
           - demo.fileyourstatetaxes.org
           - demo.getyourrefund.org
           - demo.mireembolso.org
+          - heroku.pya.fileyourstatetaxes.org
           - staging.fileyourstatetaxes.org
           - staging.getyourrefund.org
           - staging.mireembolso.org


### PR DESCRIPTION
forgot to add it to the list https://github.com/codeforamerica/tax-benefits-backend/pull/46