### PR TITLE
[FYST-2156] Add s3 policy for fargate role

### DIFF
--- a/tofu/modules/pya/main.tf
+++ b/tofu/modules/pya/main.tf
@@ -152,7 +152,6 @@ resource "aws_kms_key" "submission_pdfs" {
 # IAM policy for ECS tasks to access S3
 resource "aws_iam_policy" "ecs_s3_access" {
   name = "pya-${var.environment}-ecs-s3-access"
-  #role = split("/", module.ecs.task_execution_role_arn)[1]
 
   policy = jsonencode({
     Version = "2012-10-17"


### PR DESCRIPTION
Copied over from https://github.com/codeforamerica/asap_pdf/blob/main/terraform/main.tf example

Added an IAM policy for s3 bucket access `submission-pdfs-staging` and `submission-pdfs-production`

- [full gist here for production](https://gist.github.com/arinchoi03/3f6df4af60e24542cbce186906c5b839)
- [full gist here for staging](https://gist.github.com/arinchoi03/aa795369917e3e012cea815f062641d0)

<details>
<summary>production changes </summary>
 
```ruby
  # module.pya.aws_iam_policy.ecs_s3_access will be created
  + resource "aws_iam_policy" "ecs_s3_access" {
      + arn              = (known after apply)
      + attachment_count = (known after apply)
      + id               = (known after apply)
      + name             = "pya-production-ecs-s3-access"
      + name_prefix      = (known after apply)
      + path             = "/"
      + policy           = jsonencode(
            {
              + Statement = [
                  + {
                      + Action   = [
                          + "s3:GetObject",
                          + "s3:PutObject",
                          + "s3:ListBucket",
                          + "s3:DeleteObject",
                        ]
                      + Effect   = "Allow"
                      + Resource = [
                          + "arn:aws:s3:::submission-pdfs-production",
                          + "arn:aws:s3:::submission-pdfs-production/*",
                        ]
                    },
                ]
              + Version   = "2012-10-17"
            }
        )
      + policy_id        = (known after apply)
      + tags_all         = {
          + "environment" = "production"
          + "project"     = "pya"
        }
    }

  # module.pya.module.web.aws_iam_role_policy_attachments_exclusive.execution will be updated in-place
  ~ resource "aws_iam_role_policy_attachments_exclusive" "execution" {
      ~ policy_arns = [
          + (known after apply),
            # (3 unchanged elements hidden)
        ]
        # (1 unchanged attribute hidden)
    }

  # module.pya.module.workers.aws_iam_role_policy_attachments_exclusive.execution will be updated in-place
  ~ resource "aws_iam_role_policy_attachments_exclusive" "execution" {
      ~ policy_arns = [
          + (known after apply),
            # (3 unchanged elements hidden)
        ]
        # (1 unchanged attribute hidden)
    }

Plan: 1 to add, 2 to change, 0 to destroy.

```

</details>

<details>
<summary>staging changes </summary>

```ruby
  # module.pya.aws_iam_policy.ecs_s3_access will be created
  + resource "aws_iam_policy" "ecs_s3_access" {
      + arn              = (known after apply)
      + attachment_count = (known after apply)
      + id               = (known after apply)
      + name             = "pya-staging-ecs-s3-access"
      + name_prefix      = (known after apply)
      + path             = "/"
      + policy           = jsonencode(
            {
              + Statement = [
                  + {
                      + Action   = [
                          + "s3:GetObject",
                          + "s3:PutObject",
                          + "s3:ListBucket",
                          + "s3:DeleteObject",
                        ]
                      + Effect   = "Allow"
                      + Resource = [
                          + "arn:aws:s3:::submission-pdfs-staging",
                          + "arn:aws:s3:::submission-pdfs-staging/*",
                        ]
                    },
                ]
              + Version   = "2012-10-17"
            }
        )
      + policy_id        = (known after apply)
      + tags_all         = {
          + "environment" = "staging"
          + "project"     = "pya"
        }
    }

  # module.pya.module.web.aws_iam_role_policy_attachments_exclusive.execution will be updated in-place
  ~ resource "aws_iam_role_policy_attachments_exclusive" "execution" {
      ~ policy_arns = [
          + (known after apply),
            # (3 unchanged elements hidden)
        ]
        # (1 unchanged attribute hidden)
    }

  # module.pya.module.workers.aws_iam_role_policy_attachments_exclusive.execution will be updated in-place
  ~ resource "aws_iam_role_policy_attachments_exclusive" "execution" {
      ~ policy_arns = [
          + (known after apply),
            # (3 unchanged elements hidden)
        ]
        # (1 unchanged attribute hidden)
    }

Plan: 1 to add, 2 to change, 0 to destroy.

```

</details>