### PR TITLE
[FYST-2164] Initialize the secret SSN_HASHING_KEY for staging/prod

### DIFF
--- a/tofu/modules/pya/main.tf
+++ b/tofu/modules/pya/main.tf
@@ -30,6 +30,12 @@ module "secrets" {
       start_value = jsonencode({
         key = ""
       })
+    },
+    "ssn_hashing_key" = {
+      description = "Key for encrypting SSN for archived intakes"
+      start_value = jsonencode({
+        key = ""
+      })
     }
   }
 }
@@ -78,6 +84,7 @@ module "web" {
     DATABASE_PASSWORD      = "${module.database.secret_arn}:password"
     DATABASE_USER          = "${module.database.secret_arn}:username"
     SECRET_KEY_BASE        = "${module.secrets.secrets["rails_secret_key_base"].secret_arn}:key"
+    SSN_HASHING_KEY        = "${module.secrets.secrets["ssn_hashing_key"].secret_arn}:key"
   }
 }
 
@@ -110,6 +117,7 @@ module "workers" {
     DATABASE_PASSWORD      = "${module.database.secret_arn}:password"
     DATABASE_USER          = "${module.database.secret_arn}:username"
     SECRET_KEY_BASE        = "${module.secrets.secrets["rails_secret_key_base"].secret_arn}:key"
+    SSN_HASHING_KEY        = "${module.secrets.secrets["ssn_hashing_key"].secret_arn}:key"
   }
 }
 


### PR DESCRIPTION
[prod full changes
](https://gist.github.com/arinchoi03/ba7b288fc5b37f7e472639218e2c4b96)
<details>
<summary> prod changes </summary>

```

OpenTofu will perform the following actions:

  # module.pya.module.web.aws_iam_policy.secrets will be updated in-place
  ~ resource "aws_iam_policy" "secrets" {
        id               = "arn:aws:iam::828007041297:policy/pya-production-web-secrets-access-2025061319391678530000001f"
        name             = "pya-production-web-secrets-access-2025061319391678530000001f"
      ~ policy           = jsonencode(
            {
              - Statement = [
                  - {
                      - Action   = [
                          - "secretsmanager:GetSecretValue",
                          - "kms:Decrypt",
                          - "ssm:GetParameter",
                          - "ssm:GetParameters",
                        ]
                      - Effect   = "Allow"
                      - Resource = [
                          - "arn:aws:kms:us-east-1:828007041297:key/0254fd26-6839-4fad-9908-1c4446ba4fc3",
                          - "arn:aws:ssm:us-east-1:828007041297:parameter/pya/production/web/otel",
                          - "arn:aws:secretsmanager:us-east-1:828007041297:secret:pya/production//rails_secret_key_base-2025061319374160900000000e-XjDKE1",
                          - "arn:aws:secretsmanager:us-east-1:828007041297:secret:rds!cluster-e67cc6a9-7be0-4cfd-82bc-d52797fc614e-ToyDM6",
                        ]
                    },
                ]
              - Version   = "2012-10-17"
            }
        ) -> (known after apply)
        tags             = {}
        # (7 unchanged attributes hidden)
    }

  # module.pya.module.workers.aws_iam_policy.secrets will be updated in-place
  ~ resource "aws_iam_policy" "secrets" {
        id               = "arn:aws:iam::828007041297:policy/pya-production-worker-secrets-access-20250613195823151700000003"
        name             = "pya-production-worker-secrets-access-20250613195823151700000003"
      ~ policy           = jsonencode(
            {
              - Statement = [
                  - {
                      - Action   = [
                          - "secretsmanager:GetSecretValue",
                          - "kms:Decrypt",
                          - "ssm:GetParameter",
                          - "ssm:GetParameters",
                        ]
                      - Effect   = "Allow"
                      - Resource = [
                          - "arn:aws:kms:us-east-1:828007041297:key/e2f17e79-ae4f-4cec-9354-a699f3949f51",
                          - "arn:aws:ssm:us-east-1:828007041297:parameter/pya/production/worker/otel",
                          - "arn:aws:secretsmanager:us-east-1:828007041297:secret:pya/production//rails_secret_key_base-2025061319374160900000000e-XjDKE1",
                          - "arn:aws:secretsmanager:us-east-1:828007041297:secret:rds!cluster-e67cc6a9-7be0-4cfd-82bc-d52797fc614e-ToyDM6",
                        ]
                    },
                ]
              - Version   = "2012-10-17"
            }
        ) -> (known after apply)
        tags             = {}
        # (7 unchanged attributes hidden)
    }

  # module.pya.module.secrets.module.secrets_manager["ssn_hashing_key"].aws_secretsmanager_secret.this[0] will be created
  + resource "aws_secretsmanager_secret" "this" {
      + arn                            = (known after apply)
      + description                    = "Key for encrypting SSN for archived intakes"
      + force_overwrite_replica_secret = false
      + id                             = (known after apply)
      + kms_key_id                     = "alias/pya/production/secrets"
      + name                           = (known after apply)
      + name_prefix                    = "pya/production//ssn_hashing_key-"
      + policy                         = (known after apply)
      + recovery_window_in_days        = 30
      + tags_all                       = {
          + "environment" = "production"
          + "project"     = "pya"
        }

      + replica (known after apply)
    }

  # module.pya.module.secrets.module.secrets_manager["ssn_hashing_key"].aws_secretsmanager_secret_version.ignore_changes[0] will be created
  + resource "aws_secretsmanager_secret_version" "ignore_changes" {
      + arn                  = (known after apply)
      + has_secret_string_wo = (known after apply)
      + id                   = (known after apply)
      + secret_id            = (known after apply)
      + secret_string        = (sensitive value)
      + version_id           = (known after apply)
      + version_stages       = (known after apply)
    }

  # module.pya.module.web.module.ecs_service.module.fargate.aws_ecs_service.main[0] will be updated in-place
  ~ resource "aws_ecs_service" "main" {
        id                                 = "arn:aws:ecs:us-east-1:828007041297:service/pya-production-web/pya-production-web"
        name                               = "pya-production-web"
        tags                               = {}
      ~ task_definition                    = "arn:aws:ecs:us-east-1:828007041297:task-definition/pya-production-web:4" -> (known after apply)
        # (16 unchanged attributes hidden)

        # (4 unchanged blocks hidden)
    }

  # module.pya.module.workers.module.ecs_service.module.fargate.aws_ecs_service.main[0] will be updated in-place
  ~ resource "aws_ecs_service" "main" {
        id                                 = "arn:aws:ecs:us-east-1:828007041297:service/pya-production-worker/pya-production-worker"
        name                               = "pya-production-worker"
        tags                               = {}
      ~ task_definition                    = "arn:aws:ecs:us-east-1:828007041297:task-definition/pya-production-worker:3" -> (known after apply)
        # (16 unchanged attributes hidden)

        # (3 unchanged blocks hidden)
    }

  # module.pya.module.web.module.ecs_service.module.fargate.module.task.aws_ecs_task_definition.main[0] must be replaced
+/- resource "aws_ecs_task_definition" "main" {
      ~ arn                      = "arn:aws:ecs:us-east-1:828007041297:task-definition/pya-production-web:4" -> (known after apply)
      ~ arn_without_revision     = "arn:aws:ecs:us-east-1:828007041297:task-definition/pya-production-web" -> (known after apply)
      ~ container_definitions    = jsonencode(
            [
              - {
                  - command          = [
                      - "--config=/etc/ecs/container-insights/otel-task-metrics-config.yaml",
                    ]
                  - cpu              = 256
                  - environment      = [
                      - {
                          - name  = "OTEL_LOG_LEVEL"
                          - value = "info"
                        },
                    ]
                  - essential        = false
                  - image            = "public.ecr.aws/aws-observability/aws-otel-collector:latest"
                  - logConfiguration = {
                      - logDriver = "awslogs"
                      - options   = {
                          - awslogs-group         = "/aws/ecs/pya/production/web"
                          - awslogs-region        = "us-east-1"
                          - awslogs-stream-prefix = "otel-collector"
                        }
                    }
                  - memory           = 512
                  - mountPoints      = []
                  - name             = "otel-collector"
                  - portMappings     = []
                  - secrets          = [
                      - {
                          - name      = "AOT_CONFIG_CONTENT"
                          - valueFrom = "arn:aws:ssm:us-east-1:828007041297:parameter/pya/production/web/otel"
                        },
                    ]
                  - systemControls   = []
                  - volumesFrom      = []
                },
              - {
                  - cpu               = 256
                  - environment       = [
                      - {
                          - name  = "DATABASE_HOST"
                          - value = "pya-production-web.cluster-csjcc2coc9nm.us-east-1.rds.amazonaws.com"
                        },
                      - {
                          - name  = "RACK_ENV"
                          - value = "production"
                        },
                      - {
                          - name  = "S3_BUCKET"
                          - value = "submission-pdfs-production"
                        },
                    ]
                  - essential         = true
                  - image             = "828007041297.dkr.ecr.us-east-1.amazonaws.com/pya-production-web:latest"
                  - linuxParameters   = {
                      - initProcessEnabled = true
                    }
                  - logConfiguration  = {
                      - logDriver = "awslogs"
                      - options   = {
                          - awslogs-group         = "/aws/ecs/pya/production/web"
                          - awslogs-region        = "us-east-1"
                          - awslogs-stream-prefix = "ecs"
                        }
                    }
                  - memory            = 512
                  - memoryReservation = 512
                  - mountPoints       = []
                  - name              = "pya-production-web"
                  - portMappings      = [
                      - {
                          - containerPort = 3000
                          - hostPort      = 3000
                          - protocol      = "tcp"
                        },
                    ]
                  - secrets           = [
                      - {
                          - name      = "DATABASE_PASSWORD"
                          - valueFrom = "arn:aws:secretsmanager:us-east-1:828007041297:secret:rds!cluster-e67cc6a9-7be0-4cfd-82bc-d52797fc614e-ToyDM6:password::"
                        },
                      - {
                          - name      = "DATABASE_USER"
                          - valueFrom = "arn:aws:secretsmanager:us-east-1:828007041297:secret:rds!cluster-e67cc6a9-7be0-4cfd-82bc-d52797fc614e-ToyDM6:username::"
                        },
                      - {
                          - name      = "SECRET_KEY_BASE"
                          - valueFrom = "arn:aws:secretsmanager:us-east-1:828007041297:secret:pya/production//rails_secret_key_base-2025061319374160900000000e-XjDKE1:key::"
                        },
                    ]
                  - systemControls    = []
                  - volumesFrom       = []
                },
            ] # forces replacement
        ) -> (known after apply) # forces replacement
      ~ enable_fault_injection   = false -> (known after apply)
      ~ id                       = "pya-production-web" -> (known after apply)
      ~ revision                 = 4 -> (known after apply)
      - tags                     = {} -> null
        # (10 unchanged attributes hidden)
    }

  # module.pya.module.workers.module.ecs_service.module.fargate.module.task.aws_ecs_task_definition.main[0] must be replaced
+/- resource "aws_ecs_task_definition" "main" {
      ~ arn                      = "arn:aws:ecs:us-east-1:828007041297:task-definition/pya-production-worker:3" -> (known after apply)
      ~ arn_without_revision     = "arn:aws:ecs:us-east-1:828007041297:task-definition/pya-production-worker" -> (known after apply)
      ~ container_definitions    = jsonencode(
            [
              - {
                  - command          = [
                      - "--config=/etc/ecs/container-insights/otel-task-metrics-config.yaml",
                    ]
                  - cpu              = 256
                  - environment      = [
                      - {
                          - name  = "OTEL_LOG_LEVEL"
                          - value = "info"
                        },
                    ]
                  - essential        = false
                  - image            = "public.ecr.aws/aws-observability/aws-otel-collector:latest"
                  - logConfiguration = {
                      - logDriver = "awslogs"
                      - options   = {
                          - awslogs-group         = "/aws/ecs/pya/production/worker"
                          - awslogs-region        = "us-east-1"
                          - awslogs-stream-prefix = "otel-collector"
                        }
                    }
                  - memory           = 512
                  - mountPoints      = []
                  - name             = "otel-collector"
                  - portMappings     = []
                  - secrets          = [
                      - {
                          - name      = "AOT_CONFIG_CONTENT"
                          - valueFrom = "arn:aws:ssm:us-east-1:828007041297:parameter/pya/production/worker/otel"
                        },
                    ]
                  - systemControls   = []
                  - volumesFrom      = []
                },
              - {
                  - cpu               = 256
                  - environment       = [
                      - {
                          - name  = "DATABASE_HOST"
                          - value = "pya-production-web.cluster-csjcc2coc9nm.us-east-1.rds.amazonaws.com"
                        },
                      - {
                          - name  = "RACK_ENV"
                          - value = "production"
                        },
                      - {
                          - name  = "S3_BUCKET"
                          - value = "submission-pdfs-production"
                        },
                    ]
                  - essential         = true
                  - image             = "828007041297.dkr.ecr.us-east-1.amazonaws.com/pya-production-worker:latest"
                  - linuxParameters   = {
                      - initProcessEnabled = true
                    }
                  - logConfiguration  = {
                      - logDriver = "awslogs"
                      - options   = {
                          - awslogs-group         = "/aws/ecs/pya/production/worker"
                          - awslogs-region        = "us-east-1"
                          - awslogs-stream-prefix = "ecs"
                        }
                    }
                  - memory            = 512
                  - memoryReservation = 512
                  - mountPoints       = []
                  - name              = "pya-production-worker"
                  - portMappings      = [
                      - {
                          - containerPort = 3000
                          - hostPort      = 3000
                          - protocol      = "tcp"
                        },
                    ]
                  - secrets           = [
                      - {
                          - name      = "DATABASE_PASSWORD"
                          - valueFrom = "arn:aws:secretsmanager:us-east-1:828007041297:secret:rds!cluster-e67cc6a9-7be0-4cfd-82bc-d52797fc614e-ToyDM6:password::"
                        },
                      - {
                          - name      = "DATABASE_USER"
                          - valueFrom = "arn:aws:secretsmanager:us-east-1:828007041297:secret:rds!cluster-e67cc6a9-7be0-4cfd-82bc-d52797fc614e-ToyDM6:username::"
                        },
                      - {
                          - name      = "SECRET_KEY_BASE"
                          - valueFrom = "arn:aws:secretsmanager:us-east-1:828007041297:secret:pya/production//rails_secret_key_base-2025061319374160900000000e-XjDKE1:key::"
                        },
                    ]
                  - systemControls    = []
                  - volumesFrom       = []
                },
            ] # forces replacement
        ) -> (known after apply) # forces replacement
      ~ enable_fault_injection   = false -> (known after apply)
      ~ id                       = "pya-production-worker" -> (known after apply)
      ~ revision                 = 3 -> (known after apply)
      - tags                     = {} -> null
        # (10 unchanged attributes hidden)
    }

Plan: 4 to add, 4 to change, 2 to destroy.
```

</details>

[staging full changes
](https://gist.github.com/arinchoi03/c88f26e75ba5d43aa38ddb3cd8aeb996)
<details>
<summary> staging changes </summary>

```
  # module.pya.module.web.aws_iam_policy.secrets will be updated in-place
  ~ resource "aws_iam_policy" "secrets" {
        id               = "arn:aws:iam::300423309117:policy/pya-staging-web-secrets-access-2025060217203363480000001c"
        name             = "pya-staging-web-secrets-access-2025060217203363480000001c"
      ~ policy           = jsonencode(
            {
              - Statement = [
                  - {
                      - Action   = [
                          - "secretsmanager:GetSecretValue",
                          - "kms:Decrypt",
                          - "ssm:GetParameter",
                          - "ssm:GetParameters",
                        ]
                      - Effect   = "Allow"
                      - Resource = [
                          - "arn:aws:kms:us-east-1:300423309117:key/7e4d53b1-c546-4cb3-ab84-c55f89923872",
                          - "arn:aws:ssm:us-east-1:300423309117:parameter/pya/staging/web/otel",
                          - "arn:aws:secretsmanager:us-east-1:300423309117:secret:pya/staging//rails_secret_key_base-20250610205228067300000001-HxBP0A",
                          - "arn:aws:secretsmanager:us-east-1:300423309117:secret:rds!cluster-1c174606-0fc5-4409-aeed-714d5dde390b-Mlp93d",
                        ]
                    },
                ]
              - Version   = "2012-10-17"
            }
        ) -> (known after apply)
        tags             = {}
        # (7 unchanged attributes hidden)
    }

  # module.pya.module.workers.aws_iam_policy.secrets will be updated in-place
  ~ resource "aws_iam_policy" "secrets" {
        id               = "arn:aws:iam::300423309117:policy/pya-staging-worker-secrets-access-20250602174730998000000004"
        name             = "pya-staging-worker-secrets-access-20250602174730998000000004"
      ~ policy           = jsonencode(
            {
              - Statement = [
                  - {
                      - Action   = [
                          - "secretsmanager:GetSecretValue",
                          - "kms:Decrypt",
                          - "ssm:GetParameter",
                          - "ssm:GetParameters",
                        ]
                      - Effect   = "Allow"
                      - Resource = [
                          - "arn:aws:kms:us-east-1:300423309117:key/998915cb-47ae-4191-a372-059907397887",
                          - "arn:aws:ssm:us-east-1:300423309117:parameter/pya/staging/worker/otel",
                          - "arn:aws:secretsmanager:us-east-1:300423309117:secret:pya/staging//rails_secret_key_base-20250610205228067300000001-HxBP0A",
                          - "arn:aws:secretsmanager:us-east-1:300423309117:secret:rds!cluster-1c174606-0fc5-4409-aeed-714d5dde390b-Mlp93d",
                        ]
                    },
                ]
              - Version   = "2012-10-17"
            }
        ) -> (known after apply)
        tags             = {}
        # (7 unchanged attributes hidden)
    }

  # module.pya.module.secrets.module.secrets_manager["ssn_hashing_key"].aws_secretsmanager_secret.this[0] will be created
  + resource "aws_secretsmanager_secret" "this" {
      + arn                            = (known after apply)
      + description                    = "Key for encrypting SSN for archived intakes"
      + force_overwrite_replica_secret = false
      + id                             = (known after apply)
      + kms_key_id                     = "alias/pya/staging/secrets"
      + name                           = (known after apply)
      + name_prefix                    = "pya/staging//ssn_hashing_key-"
      + policy                         = (known after apply)
      + recovery_window_in_days        = 30
      + tags_all                       = {
          + "environment" = "staging"
          + "project"     = "pya"
        }

      + replica (known after apply)
    }

  # module.pya.module.secrets.module.secrets_manager["ssn_hashing_key"].aws_secretsmanager_secret_version.ignore_changes[0] will be created
  + resource "aws_secretsmanager_secret_version" "ignore_changes" {
      + arn                  = (known after apply)
      + has_secret_string_wo = (known after apply)
      + id                   = (known after apply)
      + secret_id            = (known after apply)
      + secret_string        = (sensitive value)
      + version_id           = (known after apply)
      + version_stages       = (known after apply)
    }

  # module.pya.module.web.module.ecs_service.module.fargate.aws_ecs_service.main[0] will be updated in-place
  ~ resource "aws_ecs_service" "main" {
        id                                 = "arn:aws:ecs:us-east-1:300423309117:service/pya-staging-web/pya-staging-web"
        name                               = "pya-staging-web"
        tags                               = {}
      ~ task_definition                    = "arn:aws:ecs:us-east-1:300423309117:task-definition/pya-staging-web:21" -> (known after apply)
        # (16 unchanged attributes hidden)

        # (4 unchanged blocks hidden)
    }

  # module.pya.module.workers.module.ecs_service.module.fargate.aws_ecs_service.main[0] will be updated in-place
  ~ resource "aws_ecs_service" "main" {
        id                                 = "arn:aws:ecs:us-east-1:300423309117:service/pya-staging-worker/pya-staging-worker"
        name                               = "pya-staging-worker"
        tags                               = {}
      ~ task_definition                    = "arn:aws:ecs:us-east-1:300423309117:task-definition/pya-staging-worker:20" -> (known after apply)
        # (16 unchanged attributes hidden)

        # (3 unchanged blocks hidden)
    }

  # module.pya.module.web.module.ecs_service.module.fargate.module.task.aws_ecs_task_definition.main[0] must be replaced
+/- resource "aws_ecs_task_definition" "main" {
      ~ arn                      = "arn:aws:ecs:us-east-1:300423309117:task-definition/pya-staging-web:21" -> (known after apply)
      ~ arn_without_revision     = "arn:aws:ecs:us-east-1:300423309117:task-definition/pya-staging-web" -> (known after apply)
      ~ container_definitions    = jsonencode(
            [
              - {
                  - command          = [
                      - "--config=/etc/ecs/container-insights/otel-task-metrics-config.yaml",
                    ]
                  - cpu              = 256
                  - environment      = [
                      - {
                          - name  = "OTEL_LOG_LEVEL"
                          - value = "info"
                        },
                    ]
                  - essential        = false
                  - image            = "public.ecr.aws/aws-observability/aws-otel-collector:latest"
                  - logConfiguration = {
                      - logDriver = "awslogs"
                      - options   = {
                          - awslogs-group         = "/aws/ecs/pya/staging/web"
                          - awslogs-region        = "us-east-1"
                          - awslogs-stream-prefix = "otel-collector"
                        }
                    }
                  - memory           = 512
                  - mountPoints      = []
                  - name             = "otel-collector"
                  - portMappings     = []
                  - secrets          = [
                      - {
                          - name      = "AOT_CONFIG_CONTENT"
                          - valueFrom = "arn:aws:ssm:us-east-1:300423309117:parameter/pya/staging/web/otel"
                        },
                    ]
                  - systemControls   = []
                  - volumesFrom      = []
                },
              - {
                  - cpu               = 256
                  - environment       = [
                      - {
                          - name  = "DATABASE_HOST"
                          - value = "pya-staging-web.cluster-ckh4cgkekf60.us-east-1.rds.amazonaws.com"
                        },
                      - {
                          - name  = "RACK_ENV"
                          - value = "staging"
                        },
                      - {
                          - name  = "S3_BUCKET"
                          - value = "submission-pdfs-staging"
                        },
                    ]
                  - essential         = true
                  - image             = "300423309117.dkr.ecr.us-east-1.amazonaws.com/pya-staging-web:ba158098e52503fa2c953c336da2e2e30538d8ce"
                  - linuxParameters   = {
                      - initProcessEnabled = true
                    }
                  - logConfiguration  = {
                      - logDriver = "awslogs"
                      - options   = {
                          - awslogs-group         = "/aws/ecs/pya/staging/web"
                          - awslogs-region        = "us-east-1"
                          - awslogs-stream-prefix = "ecs"
                        }
                    }
                  - memory            = 512
                  - memoryReservation = 512
                  - mountPoints       = []
                  - name              = "pya-staging-web"
                  - portMappings      = [
                      - {
                          - containerPort = 3000
                          - hostPort      = 3000
                          - protocol      = "tcp"
                        },
                    ]
                  - secrets           = [
                      - {
                          - name      = "DATABASE_PASSWORD"
                          - valueFrom = "arn:aws:secretsmanager:us-east-1:300423309117:secret:rds!cluster-1c174606-0fc5-4409-aeed-714d5dde390b-Mlp93d:password::"
                        },
                      - {
                          - name      = "DATABASE_USER"
                          - valueFrom = "arn:aws:secretsmanager:us-east-1:300423309117:secret:rds!cluster-1c174606-0fc5-4409-aeed-714d5dde390b-Mlp93d:username::"
                        },
                      - {
                          - name      = "SECRET_KEY_BASE"
                          - valueFrom = "arn:aws:secretsmanager:us-east-1:300423309117:secret:pya/staging//rails_secret_key_base-20250610205228067300000001-HxBP0A:key::"
                        },
                    ]
                  - systemControls    = []
                  - volumesFrom       = []
                },
            ] # forces replacement
        ) -> (known after apply) # forces replacement
      ~ enable_fault_injection   = false -> (known after apply)
      ~ id                       = "pya-staging-web" -> (known after apply)
      ~ revision                 = 21 -> (known after apply)
      - tags                     = {} -> null
        # (10 unchanged attributes hidden)
    }

  # module.pya.module.workers.module.ecs_service.module.fargate.module.task.aws_ecs_task_definition.main[0] must be replaced
+/- resource "aws_ecs_task_definition" "main" {
      ~ arn                      = "arn:aws:ecs:us-east-1:300423309117:task-definition/pya-staging-worker:20" -> (known after apply)
      ~ arn_without_revision     = "arn:aws:ecs:us-east-1:300423309117:task-definition/pya-staging-worker" -> (known after apply)
      ~ container_definitions    = jsonencode(
            [
              - {
                  - command          = [
                      - "--config=/etc/ecs/container-insights/otel-task-metrics-config.yaml",
                    ]
                  - cpu              = 256
                  - environment      = [
                      - {
                          - name  = "OTEL_LOG_LEVEL"
                          - value = "info"
                        },
                    ]
                  - essential        = false
                  - image            = "public.ecr.aws/aws-observability/aws-otel-collector:latest"
                  - logConfiguration = {
                      - logDriver = "awslogs"
                      - options   = {
                          - awslogs-group         = "/aws/ecs/pya/staging/worker"
                          - awslogs-region        = "us-east-1"
                          - awslogs-stream-prefix = "otel-collector"
                        }
                    }
                  - memory           = 512
                  - mountPoints      = []
                  - name             = "otel-collector"
                  - portMappings     = []
                  - secrets          = [
                      - {
                          - name      = "AOT_CONFIG_CONTENT"
                          - valueFrom = "arn:aws:ssm:us-east-1:300423309117:parameter/pya/staging/worker/otel"
                        },
                    ]
                  - systemControls   = []
                  - volumesFrom      = []
                },
              - {
                  - cpu               = 256
                  - environment       = [
                      - {
                          - name  = "DATABASE_HOST"
                          - value = "pya-staging-web.cluster-ckh4cgkekf60.us-east-1.rds.amazonaws.com"
                        },
                      - {
                          - name  = "RACK_ENV"
                          - value = "staging"
                        },
                      - {
                          - name  = "S3_BUCKET"
                          - value = "submission-pdfs-staging"
                        },
                    ]
                  - essential         = true
                  - image             = "300423309117.dkr.ecr.us-east-1.amazonaws.com/pya-staging-worker:ba158098e52503fa2c953c336da2e2e30538d8ce"
                  - linuxParameters   = {
                      - initProcessEnabled = true
                    }
                  - logConfiguration  = {
                      - logDriver = "awslogs"
                      - options   = {
                          - awslogs-group         = "/aws/ecs/pya/staging/worker"
                          - awslogs-region        = "us-east-1"
                          - awslogs-stream-prefix = "ecs"
                        }
                    }
                  - memory            = 512
                  - memoryReservation = 512
                  - mountPoints       = []
                  - name              = "pya-staging-worker"
                  - portMappings      = [
                      - {
                          - containerPort = 3000
                          - hostPort      = 3000
                          - protocol      = "tcp"
                        },
                    ]
                  - secrets           = [
                      - {
                          - name      = "DATABASE_PASSWORD"
                          - valueFrom = "arn:aws:secretsmanager:us-east-1:300423309117:secret:rds!cluster-1c174606-0fc5-4409-aeed-714d5dde390b-Mlp93d:password::"
                        },
                      - {
                          - name      = "DATABASE_USER"
                          - valueFrom = "arn:aws:secretsmanager:us-east-1:300423309117:secret:rds!cluster-1c174606-0fc5-4409-aeed-714d5dde390b-Mlp93d:username::"
                        },
                      - {
                          - name      = "SECRET_KEY_BASE"
                          - valueFrom = "arn:aws:secretsmanager:us-east-1:300423309117:secret:pya/staging//rails_secret_key_base-20250610205228067300000001-HxBP0A:key::"
                        },
                    ]
                  - systemControls    = []
                  - volumesFrom       = []
                },
            ] # forces replacement
        ) -> (known after apply) # forces replacement
      ~ enable_fault_injection   = false -> (known after apply)
      ~ id                       = "pya-staging-worker" -> (known after apply)
      ~ revision                 = 20 -> (known after apply)
      - tags                     = {} -> null
        # (10 unchanged attributes hidden)
    }

Plan: 4 to add, 4 to change, 2 to destroy.
```
</details>

After this is applied, I'm going into the AWS Secrets Manager, generating a new key (`SecureRandom.hex(32)`) for each of the env (different for both) and pasting it into the `ssn_hashing_key` value