### PR TITLE
[FYST-2169] Add policy for KMS key to add seeds submission_pdf to S3

### DIFF
--- a/tofu/modules/pya/main.tf
+++ b/tofu/modules/pya/main.tf
@@ -175,11 +175,16 @@ resource "aws_iam_policy" "ecs_s3_access" {
           "s3:GetObject",
           "s3:PutObject",
           "s3:ListBucket",
-          "s3:DeleteObject"
+          "s3:DeleteObject",
+          "kms:Decrypt",
+          "kms:Encrypt",
+          "kms:GenerateDataKey",
+          "kms:DescribeKey",
         ]
         Resource = [
           aws_s3_bucket.submission_pdfs.arn,
-          "${aws_s3_bucket.submission_pdfs.arn}/*"
+          "${aws_s3_bucket.submission_pdfs.arn}/*",
+          aws_kms_key.submission_pdfs.arn
         ]
       }
     ]


### PR DESCRIPTION
https://codeforamerica.atlassian.net/browse/FYST-2169

Saw we had error logs like on staging ecs task logs (checking if the seeds got generated):
```

Aws::S3::Errors::AccessDenied: User: arn:aws:sts::<account_sid>:assumed-role/pya-staging-web-task/<task_id> is not authorized to perform: kms:GenerateDataKey on resource: arn:aws:kms:us-east-1:<account_sid>:key/<key> because no identity-based policy allows the kms:GenerateDataKey action (Aws::S3::Errors::AccessDenied) 

```

**Staging changes summary**
```
  # module.pya.aws_iam_policy.ecs_s3_access will be updated in-place
  ~ resource "aws_iam_policy" "ecs_s3_access" {
        id               = "arn:aws:iam::300423309117:policy/pya-staging-ecs-s3-access"
        name             = "pya-staging-ecs-s3-access"
      ~ policy           = jsonencode(
          ~ {
              ~ Statement = [
                  ~ {
                      ~ Action   = [
                            # (3 unchanged elements hidden)
                            "s3:DeleteObject",
                          + "kms:Decrypt",
                          + "kms:Encrypt",
                          + "kms:GenerateDataKey",
                          + "kms:DescribeKey",
                        ]
                      ~ Resource = [
                            # (1 unchanged element hidden)
                            "arn:aws:s3:::submission-pdfs-staging/*",
                          + "arn:aws:kms:us-east-1:300423309117:key/82cfa843-4288-421b-aef9-12de4cfc84b7",
                        ]
                        # (1 unchanged attribute hidden)
                    },
                ]
                # (1 unchanged attribute hidden)
            }
        )
        tags             = {}
        # (5 unchanged attributes hidden)
    }

Plan: 0 to add, 1 to change, 0 to destroy.
```

**prod changes summary**
```
  # module.pya.aws_iam_policy.ecs_s3_access will be updated in-place
  ~ resource "aws_iam_policy" "ecs_s3_access" {
        id               = "arn:aws:iam::828007041297:policy/pya-production-ecs-s3-access"
        name             = "pya-production-ecs-s3-access"
      ~ policy           = jsonencode(
          ~ {
              ~ Statement = [
                  ~ {
                      ~ Action   = [
                            # (3 unchanged elements hidden)
                            "s3:DeleteObject",
                          + "kms:Decrypt",
                          + "kms:Encrypt",
                          + "kms:GenerateDataKey",
                          + "kms:DescribeKey",
                        ]
                      ~ Resource = [
                            # (1 unchanged element hidden)
                            "arn:aws:s3:::submission-pdfs-production/*",
                          + "arn:aws:kms:us-east-1:828007041297:key/32a645c6-68df-4743-a1f1-3bbff1367aea",
                        ]
                        # (1 unchanged attribute hidden)
                    },
                ]
                # (1 unchanged attribute hidden)
            }
        )
        tags             = {}
        # (5 unchanged attributes hidden)
    }

Plan: 0 to add, 1 to change, 0 to destroy.
```