### PR TITLE
Updated policy for KMS key

### DIFF
--- a/tofu/modules/pya/main.tf
+++ b/tofu/modules/pya/main.tf
@@ -158,7 +158,8 @@ resource "aws_kms_key" "submission_pdfs" {
   policy = templatefile("${path.module}/templates/key-policy.json.tftpl", {
     account_id : data.aws_caller_identity.identity.account_id,
     partition : data.aws_partition.current.partition,
-    bucket_arn : aws_s3_bucket.submission_pdfs.bucket
+    bucket_arn : aws_s3_bucket.submission_pdfs.bucket,
+    task_role_arn: "arn:aws:iam::${data.aws_caller_identity.identity.account_id}:role/pya-${var.environment}-*"
   })
 }
 

--- a/tofu/modules/pya/templates/key-policy.json.tftpl
+++ b/tofu/modules/pya/templates/key-policy.json.tftpl
@@ -33,6 +33,18 @@
             ]
         }
       }
+    },
+    {
+          "Sid": "Allow ECS Task to use KMS key",
+          "Effect": "Allow",
+          "Principal": {
+            "AWS": "${task_role_arn}"
+          },
+          "Action": [
+            "kms:GenerateDataKey",
+            "kms:Decrypt"
+          ],
+          "Resource": "*"
     }
   ]
 }


### PR DESCRIPTION
Still saw this error:
```
Aws::S3::Errors::AccessDenied: User: arn:aws:sts::<account_id>:assumed-role/pya-staging-web-task/<task> is not authorized to perform: kms:GenerateDataKey on resource: arn:aws:kms:us-east-1:<account_id>:key/<key> because no identity-based policy allows the kms:GenerateDataKey action (Aws::S3::Errors::AccessDenied) 
```

This should allow the ECS role to generate the data key