### PR TITLE
[FYST-2169] Pass on the policy to the web/worker task policies

### DIFF
--- a/tofu/modules/pya/main.tf
+++ b/tofu/modules/pya/main.tf
@@ -109,6 +109,7 @@ module "workers" {
   create_endpoint = false
 
   execution_policies = [aws_iam_policy.ecs_s3_access.arn]
+  task_policies = [aws_iam_policy.ecs_s3_access.arn]
 
   environment_variables = {
     RACK_ENV = var.environment


### PR DESCRIPTION
```
Aws::S3::Errors::AccessDenied: User: arn:aws:sts::<account_id>:assumed-role/pya-staging-web-task/<redacted> is not authorized to perform: s3:PutObject on resource: "arn:aws:s3:::submission-pdfs-staging/<resource_id>" because no identity-based policy allows the s3:PutObject action (Aws::S3::Errors::AccessDenied)
```

before we were passing the policies to `execution_policies` but looks like we needed them for `task_policies` for the app to be able to seed + upload the pdfs to s3 buckets

From [stackoverflow](https://stackoverflow.com/a/49947471)

> Referring to [the documentation](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task_execution_IAM_role.html) you can see that the execution role is the IAM role that executes ECS actions such as pulling the image and storing the application logs in cloudwatch.

>The TaskRole then, is the IAM role used by the task itself. For example, if your container wants to call other AWS services like S3, SQS, etc then those permissions would need to be covered by the TaskRole.

>Using a TaskRole is functionally the same as using access keys in a config file on the container instance. Using access keys in this way is not secure and is considered very bad practice. I include this in the answer because many people reading this already understand access keys.



staging changes:
```
  # module.pya.module.web.aws_iam_role_policy_attachments_exclusive.task will be updated in-place
  ~ resource "aws_iam_role_policy_attachments_exclusive" "task" {
      ~ policy_arns = [
          + "arn:aws:iam::300423309117:policy/pya-staging-ecs-s3-access",
            # (4 unchanged elements hidden)
        ]
        # (1 unchanged attribute hidden)
    }

  # module.pya.module.workers.aws_iam_role_policy_attachments_exclusive.task will be updated in-place
  ~ resource "aws_iam_role_policy_attachments_exclusive" "task" {
      ~ policy_arns = [
          + "arn:aws:iam::300423309117:policy/pya-staging-ecs-s3-access",
            # (4 unchanged elements hidden)
        ]
        # (1 unchanged attribute hidden)
    }

Plan: 0 to add, 2 to change, 0 to destroy.
```