### PR TITLE
Fyst 2171 look into adding bastion module to allow ssh access for devs

### DIFF
--- a/tofu/modules/pya/main.tf
+++ b/tofu/modules/pya/main.tf
@@ -139,6 +139,7 @@ module "database" {
   subnets         = module.vpc.private_subnets
   ingress_cidrs   = module.vpc.private_subnets_cidr_blocks
   iam_authentication = false
+  enable_data_api = true
 
   min_capacity = 2
   max_capacity = 32


### PR DESCRIPTION
[staging changes](https://gist.github.com/arinchoi03/c78ea9c043ae97edd476a92dba7b048f)
[prod changes](https://gist.github.com/arinchoi03/4711840bdd66af44a385a3bc45b91010)

- I added the [bastion module](https://github.com/codeforamerica/tofu-modules-aws-ssm-bastion)
> This allows users to connect to the instance as an entry point to the VPC without needing to manage SSH keys or open the instance to the internet.
- I created the ECS key-pair[ following instructions](https://github.com/codeforamerica/tofu-modules-aws-ssm-bastion?tab=readme-ov-file#key_pair_name) and saved the private key (`.pem`) file in lastpass
- I added the `enable_data_api` flag on the database