### PR TITLE
[FYST-2179] Enable execute_command so we can rails console deployed environments from dev environment fix bastion key-pair reference

### DIFF
--- a/tofu/modules/pya/main.tf
+++ b/tofu/modules/pya/main.tf
@@ -202,7 +202,7 @@ module "bastion" {
 
   project            = "pya"
   environment        = var.environment
-  key_pair_name      = "pya-staging-bastion"
+  key_pair_name      = "pya-${var.environment}-bastion"
   private_subnet_ids = module.vpc.private_subnets
   vpc_id             = module.vpc.vpc_id
 }


### PR DESCRIPTION
AWS ECS exec documentation:
https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-exec.html

[option available in the fargate module
](https://github.com/codeforamerica/tofu-modules-aws-fargate-service?tab=readme-ov-file#inputs)


Name | Description | Type | Default | Required
-- | -- | -- | -- | --
enable_execute_command | Enable the [ECS ExecuteCommand](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-exec.html) | bool | false | no

[staging changes](https://gist.github.com/arinchoi03/e6493286df95762416e476a038c69719)
[prod changes](https://gist.github.com/arinchoi03/c36cdeb8a14758205f40329887c6b00f)