### PR TITLE
[FYST-2183] Reduce capacity to reduce idle db cost

### DIFF
--- a/tofu/modules/pya/main.tf
+++ b/tofu/modules/pya/main.tf
@@ -143,8 +143,8 @@ module "database" {
   iam_authentication = false
   enable_data_api = true
 
-  min_capacity = 2
-  max_capacity = 32
+  min_capacity = 0
+  max_capacity = 10
   cluster_parameters = []
 }
 


### PR DESCRIPTION
https://codeforamerica.atlassian.net/browse/FYST-2183

**AFTER THIS IS MERGED, PLEASE RUN THE DEPLOY GITHUB ACTIONS ON BOTH STAGING/PRODUCTION TO IMPLEMENT THE CHANGES**

staging changes:
```
OpenTofu will perform the following actions:

  # module.pya.module.database.module.database.aws_rds_cluster.this[0] will be updated in-place
  ~ resource "aws_rds_cluster" "this" {
        id                                    = "pya-staging-web"
        tags                                  = {}
        # (47 unchanged attributes hidden)

      ~ serverlessv2_scaling_configuration {
          ~ max_capacity             = 32 -> 10
          ~ min_capacity             = 2 -> 0
            # (1 unchanged attribute hidden)
        }

        # (1 unchanged block hidden)
    }

Plan: 0 to add, 1 to change, 0 to destroy.
```

production changes:
```
OpenTofu will perform the following actions:

  # module.pya.module.database.module.database.aws_rds_cluster.this[0] will be updated in-place
  ~ resource "aws_rds_cluster" "this" {
        id                                    = "pya-production-web"
        tags                                  = {}
        # (47 unchanged attributes hidden)

      ~ serverlessv2_scaling_configuration {
          ~ max_capacity             = 32 -> 10
          ~ min_capacity             = 2 -> 0
            # (1 unchanged attribute hidden)
        }

        # (1 unchanged block hidden)
    }

Plan: 0 to add, 1 to change, 0 to destroy.
```
```