### PR TITLE
fix: Re-enable IAM database authentication.

### DIFF
--- a/.github/workflows/plan.yaml
+++ b/.github/workflows/plan.yaml
@@ -40,9 +40,12 @@ on:
           - demo.fileyourstatetaxes.org
           - demo.getyourrefund.org
           - demo.mireembolso.org
+          - heroku.pya.fileyourstatetaxes.org
           - staging.fileyourstatetaxes.org
           - staging.getyourrefund.org
           - staging.mireembolso.org
+          - staging.pya.fileyourstatetaxes.org
+          - pya.fileyourstatetaxes.org
           - www.fileyourstatetaxes.org
           - www.getctc.org
           - www.getyourrefund.org

--- a/tofu/modules/pya/main.tf
+++ b/tofu/modules/pya/main.tf
@@ -152,7 +152,7 @@ module "workers" {
 }
 
 module "database" {
-  source = "github.com/codeforamerica/tofu-modules-aws-serverless-database?ref=log-exports"
+  source = "github.com/codeforamerica/tofu-modules-aws-serverless-database?ref=1.3.1"
 
   project     = "pya"
   environment = var.environment
@@ -164,7 +164,7 @@ module "database" {
   vpc_id          = module.vpc.vpc_id
   subnets         = module.vpc.private_subnets
   ingress_cidrs   = module.vpc.private_subnets_cidr_blocks
-  iam_authentication = false
+  iam_authentication = true
   enable_data_api = true
 
   min_capacity = 0


### PR DESCRIPTION
This was initially disabled because AWS was failing to export the auth logs when enabled. The underlying issue appears to be resolved.