### PR TITLE
Efiler API: name secret keys instead of using default name

### DIFF
--- a/tofu/config/demo.efilerapi.org/main.tf
+++ b/tofu/config/demo.efilerapi.org/main.tf
@@ -64,6 +64,7 @@ module "secrets" {
   secrets = {
     "efiler-api-client-mef-credentials/efiler_api_test_client" = {
       description = "mef credentials for api_test_client"
+      name = "efiler-api-client-mef-credentials/efiler_api_test_client"
       start_value = jsonencode({
         app_sys_id = ""
         etin = ""
@@ -74,6 +75,7 @@ module "secrets" {
     },
     "efiler-api-client-mef-credentials/efiler_api_test_client_two" = {
       description = "mef credentials for api_test_client_two"
+      name = "efiler-api-client-mef-credentials/efiler_api_test_client_two"
       start_value = jsonencode({
         app_sys_id = ""
         etin = ""


### PR DESCRIPTION
didn't like the default names of the new secret keys

```
module.vpc.module.vpc.data.aws_iam_policy_document.flow_log_cloudwatch_assume_role[0]: Reading...
module.logging.data.aws_region.current: Reading...
module.logging.data.aws_lambda_functions.all: Reading...
module.backend.data.aws_caller_identity.identity: Reading...
module.secrets.data.aws_caller_identity.identity: Reading...
module.logging.data.aws_partition.current: Reading...
module.web.module.ecr["this"].data.aws_partition.current: Reading...
module.logging.module.s3.data.aws_caller_identity.current: Reading...
module.web.module.ecs.aws_ecs_cluster.main: Refreshing state... [id=arn:aws:ecs:us-east-1:669097061340:cluster/efiler-api-demo-web]
module.logging.data.aws_partition.current: Read complete after 0s [id=aws]
module.web.module.ecr["this"].data.aws_partition.current: Read complete after 0s [id=aws]
module.logging.data.aws_region.current: Read complete after 0s [id=us-east-1]
module.backend.aws_s3_bucket.tfstate: Refreshing state... [id=efiler-api-demo-tfstate]
module.logging.data.aws_elb_service_account.current: Reading...
module.vpc.module.vpc.data.aws_iam_policy_document.flow_log_cloudwatch_assume_role[0]: Read complete after 0s [id=1021377347]
module.logging.data.aws_elb_service_account.current: Read complete after 0s [id=127311923021]
module.web.data.aws_region.current: Reading...
module.web.data.aws_region.current: Read complete after 0s [id=us-east-1]
module.secrets.data.aws_partition.current: Reading...
module.web.aws_iam_role.execution: Refreshing state... [id=efiler-api-demo-web-execution]
module.logging.data.aws_caller_identity.identity: Reading...
module.logging.module.s3.aws_s3_bucket.main: Refreshing state... [id=efiler-api-demo-logs]
module.secrets.data.aws_partition.current: Read complete after 0s [id=aws]
module.vpc.module.vpc.aws_vpc.this[0]: Refreshing state... [id=vpc-0993eae38281e27a5]
module.logging.module.s3.data.aws_caller_identity.current: Read complete after 0s [id=669097061340]
module.secrets.data.aws_region.current: Reading...
module.secrets.data.aws_region.current: Read complete after 0s [id=us-east-1]
module.web.aws_acm_certificate.endpoint["this"]: Refreshing state... [id=arn:aws:acm:us-east-1:669097061340:certificate/9472c444-00cd-4959-b5df-b99f31c734ea]
module.backend.data.aws_caller_identity.identity: Read complete after 0s [id=669097061340]
module.web.aws_iam_role.task: Refreshing state... [id=efiler-api-demo-web-task]
module.secrets.data.aws_caller_identity.identity: Read complete after 0s [id=669097061340]
module.web.data.aws_caller_identity.identity: Reading...
module.logging.data.aws_caller_identity.identity: Read complete after 0s [id=669097061340]
module.web.module.otel_config.aws_ssm_parameter.this[0]: Refreshing state... [id=/efiler-api/demo/web/otel]
module.web.data.aws_caller_identity.identity: Read complete after 0s [id=669097061340]
module.vpc.data.aws_vpc_endpoint_service.services["ec2messages"]: Reading...
module.logging.data.aws_lambda_functions.all: Read complete after 1s [id=us-east-1]
module.vpc.data.aws_vpc_endpoint_service.services["ssm-contacts"]: Reading...
module.vpc.data.aws_vpc_endpoint_service.services["ecr.dkr"]: Reading...
module.vpc.data.aws_vpc_endpoint_service.services["ssm"]: Reading...
module.vpc.data.aws_vpc_endpoint_service.services["ssm-contacts"]: Read complete after 0s [id=3701104373]
module.vpc.data.aws_vpc_endpoint_service.services["ec2messages"]: Read complete after 1s [id=2187510914]
module.logging.module.s3.data.aws_partition.current: Reading...
module.vpc.data.aws_vpc_endpoint_service.services["ec2"]: Reading...
module.logging.module.s3.data.aws_partition.current: Read complete after 0s [id=aws]
module.vpc.data.aws_vpc_endpoint_service.services["ssm-incidents"]: Reading...
module.vpc.data.aws_vpc_endpoint_service.services["guardduty-data"]: Reading...
module.vpc.data.aws_vpc_endpoint_service.services["ssmmessages"]: Reading...
module.vpc.data.aws_vpc_endpoint_service.services["ecr.dkr"]: Read complete after 0s [id=1314884315]
module.vpc.data.aws_vpc_endpoint_service.services["ecr.api"]: Reading...
module.vpc.data.aws_availability_zones.available: Reading...
module.vpc.data.aws_vpc_endpoint_service.services["ssm"]: Read complete after 0s [id=874300523]
module.vpc.module.vpc.data.aws_caller_identity.current[0]: Reading...
module.vpc.data.aws_vpc_endpoint_service.services["ec2"]: Read complete after 0s [id=2644592029]
module.web.module.ecr["this"].data.aws_caller_identity.current: Reading...
module.vpc.data.aws_vpc_endpoint_service.services["ssm-incidents"]: Read complete after 0s [id=3798321550]
module.web.data.aws_route53_zone.domain["this"]: Reading...
module.vpc.module.vpc.data.aws_caller_identity.current[0]: Read complete after 0s [id=669097061340]
module.vpc.module.vpc.data.aws_region.current[0]: Reading...
module.vpc.module.vpc.data.aws_region.current[0]: Read complete after 0s [id=us-east-1]
module.backend.data.aws_partition.current: Reading...
module.backend.data.aws_partition.current: Read complete after 0s [id=aws]
module.vpc.module.vpc.data.aws_partition.current[0]: Reading...
module.vpc.module.vpc.data.aws_partition.current[0]: Read complete after 0s [id=aws]
module.logging.module.s3.data.aws_organizations_organization.current: Reading...
module.vpc.data.aws_vpc_endpoint_service.services["guardduty-data"]: Read complete after 0s [id=3795168285]
module.web.aws_ssm_parameter.version["this"]: Refreshing state... [id=/efiler-api/demo/web/version]
module.vpc.data.aws_vpc_endpoint_service.services["ssmmessages"]: Read complete after 0s [id=1315226949]
module.logging.module.s3.data.aws_region.current: Reading...
module.logging.module.s3.data.aws_region.current: Read complete after 0s [id=us-east-1]
module.web.data.aws_partition.current: Reading...
module.web.data.aws_partition.current: Read complete after 0s [id=aws]
module.web.module.alb["this"].data.aws_partition.current: Reading...
module.web.module.alb["this"].data.aws_partition.current: Read complete after 0s [id=aws]
module.vpc.module.vpc.aws_iam_role.vpc_flow_log_cloudwatch[0]: Refreshing state... [id=vpc-flow-log-role-20250730210310507700000001]
module.web.module.ecr["this"].data.aws_caller_identity.current: Read complete after 0s [id=669097061340]
module.secrets.aws_kms_key.secrets: Refreshing state... [id=e999b080-a5ad-4e7b-b5f9-4d3254a5d09d]
module.vpc.data.aws_vpc_endpoint_service.services["ecr.api"]: Read complete after 0s [id=1808222790]
module.web.module.ecs.aws_ecs_cluster_capacity_providers.main[0]: Refreshing state... [id=efiler-api-demo-web]
module.vpc.data.aws_availability_zones.available: Read complete after 0s [id=us-east-1]
module.web.aws_kms_key.fargate: Refreshing state... [id=29e0f417-029f-4f00-ba0a-25f2ace7fd8d]
module.web.module.ecr["this"].data.aws_iam_policy_document.repository[0]: Reading...
module.web.module.ecr["this"].data.aws_iam_policy_document.repository[0]: Read complete after 0s [id=3720815253]
module.web.data.aws_ssm_parameter.version["/efiler-api/demo/web/version"]: Reading...
module.web.data.aws_ssm_parameter.version["/efiler-api/demo/web/version"]: Read complete after 0s [id=/efiler-api/demo/web/version]
module.web.data.aws_route53_zone.domain["this"]: Read complete after 1s [id=Z02785241R5HD9XU9LQQU]
module.web.aws_route53_record.endpoint_validation["demo.efiler-api.fileyourstatetaxes.org"]: Refreshing state... [id=Z02785241R5HD9XU9LQQU__51dfcb6f000aff8b10559a26ff38da83.demo.efiler-api.fileyourstatetaxes.org._CNAME]
module.logging.module.s3.data.aws_organizations_organization.current: Read complete after 1s [id=o-f5mr0gq6lc]
module.secrets.aws_kms_alias.secrets: Refreshing state... [id=alias/efiler-api/demo/secrets]
module.web.aws_kms_alias.fargate: Refreshing state... [id=alias/efiler-api/demo/web]
module.web.module.ecr["this"].aws_ecr_repository.this[0]: Refreshing state... [id=efiler-api-demo-web]
module.vpc.module.vpc.aws_default_security_group.this[0]: Refreshing state... [id=sg-09696edd1ae30667b]
module.vpc.module.vpc.aws_default_network_acl.this[0]: Refreshing state... [id=acl-0b204dc9fd4df1c75]
module.vpc.module.vpc.aws_default_route_table.default[0]: Refreshing state... [id=rtb-0c34aa9efc6442389]
module.vpc.module.vpc.aws_route_table.private[0]: Refreshing state... [id=rtb-0b6171edd0d71882c]
module.vpc.module.vpc.aws_route_table.private[1]: Refreshing state... [id=rtb-043b883fe643054f3]
module.vpc.module.vpc.aws_route_table.private[2]: Refreshing state... [id=rtb-09c97d313ce6469d6]
module.vpc.module.vpc.aws_route_table.public[0]: Refreshing state... [id=rtb-00d56018d8f0dd104]
module.vpc.module.vpc.aws_subnet.public[0]: Refreshing state... [id=subnet-00848611ea831cb70]
module.vpc.module.vpc.aws_subnet.public[1]: Refreshing state... [id=subnet-0bd982d60dcbb033c]
module.vpc.module.vpc.aws_subnet.public[2]: Refreshing state... [id=subnet-0de5004315d4779b3]
module.vpc.module.vpc.aws_internet_gateway.this[0]: Refreshing state... [id=igw-0af6d28346f8e6587]
module.vpc.module.vpc.aws_subnet.private[2]: Refreshing state... [id=subnet-05904735ca7c78827]
module.vpc.module.vpc.aws_subnet.private[0]: Refreshing state... [id=subnet-0d0a4c290054abff4]
module.vpc.module.vpc.aws_subnet.private[1]: Refreshing state... [id=subnet-0677be647cf23fecd]
module.backend.aws_kms_key.backend: Refreshing state... [id=2e17466a-0844-4d56-b630-19aa544fc6eb]
module.backend.aws_s3_bucket_lifecycle_configuration.tfstate: Refreshing state... [id=efiler-api-demo-tfstate]
module.backend.aws_s3_bucket_logging.tfstate: Refreshing state... [id=efiler-api-demo-tfstate]
module.backend.aws_s3_bucket_public_access_block.tfstate: Refreshing state... [id=efiler-api-demo-tfstate]
module.backend.aws_s3_bucket_policy.tfstate: Refreshing state... [id=efiler-api-demo-tfstate]
module.backend.aws_s3_bucket_versioning.tfstate: Refreshing state... [id=efiler-api-demo-tfstate]
module.logging.module.s3.data.aws_iam_policy_document.default: Reading...
module.logging.module.s3.data.aws_iam_policy_document.default: Read complete after 0s [id=527954996]
module.logging.module.s3.aws_s3_bucket_server_side_encryption_configuration.main: Refreshing state... [id=efiler-api-demo-logs]
module.logging.module.s3.aws_s3_bucket_versioning.main: Refreshing state... [id=efiler-api-demo-logs]
module.logging.module.s3.aws_s3_bucket_public_access_block.main: Refreshing state... [id=efiler-api-demo-logs]
module.logging.module.s3.aws_s3_bucket_ownership_controls.main: Refreshing state... [id=efiler-api-demo-logs]
module.web.aws_acm_certificate_validation.endpoint["this"]: Refreshing state... [id=2025-07-30 21:03:23.495 +0000 UTC]
module.vpc.module.vpc.aws_eip.nat[0]: Refreshing state... [id=eipalloc-0ed0a6af2346dc1b8]
module.vpc.module.vpc.aws_eip.nat[2]: Refreshing state... [id=eipalloc-0f3a530cec5991df3]
module.vpc.module.vpc.aws_eip.nat[1]: Refreshing state... [id=eipalloc-0729459b41605a542]
module.vpc.module.vpc.aws_route.public_internet_gateway[0]: Refreshing state... [id=r-rtb-00d56018d8f0dd1041080289494]
module.vpc.module.vpc.aws_route_table_association.public[1]: Refreshing state... [id=rtbassoc-0dfdbc0e8d5af3b34]
module.vpc.module.vpc.aws_route_table_association.public[0]: Refreshing state... [id=rtbassoc-0032ff0b476646b48]
module.vpc.module.vpc.aws_route_table_association.public[2]: Refreshing state... [id=rtbassoc-026e61d811daca529]
module.logging.aws_s3_bucket_object_lock_configuration.lock["this"]: Refreshing state... [id=efiler-api-demo-logs]
module.logging.aws_kms_key.logs: Refreshing state... [id=9c45746a-7265-4831-b6c0-0cefa41c7a42]
module.vpc.module.vpc.aws_route_table_association.private[2]: Refreshing state... [id=rtbassoc-0e468ff1bbed4fc5c]
module.vpc.module.vpc.aws_route_table_association.private[0]: Refreshing state... [id=rtbassoc-00a2fd6c255ca33f3]
module.vpc.module.vpc.aws_route_table_association.private[1]: Refreshing state... [id=rtbassoc-0e66889e788fd5139]
module.vpc.module.endpoints.aws_security_group.this[0]: Refreshing state... [id=sg-07e77dce1a0c660f6]
module.backend.aws_kms_alias.backend: Refreshing state... [id=alias/efiler-api/demo/backend]
module.backend.aws_s3_bucket_server_side_encryption_configuration.tfstate: Refreshing state... [id=efiler-api-demo-tfstate]
module.backend.aws_dynamodb_table.tfstate_lock: Refreshing state... [id=demo.tfstate]
module.web.module.ecr["this"].aws_ecr_repository_policy.this[0]: Refreshing state... [id=efiler-api-demo-web]
module.web.module.ecr["this"].aws_ecr_lifecycle_policy.this[0]: Refreshing state... [id=efiler-api-demo-web]
module.web.aws_iam_policy.secrets: Refreshing state... [id=arn:aws:iam::669097061340:policy/efiler-api-demo-web-secrets-access-20250730210320585900000003]
module.secrets.module.secrets_manager["efiler-api-client-mef-credentials/efiler_api_test_client_two"].aws_secretsmanager_secret.this[0]: Refreshing state... [id=arn:aws:secretsmanager:us-east-1:669097061340:secret:efiler-api/demo//efiler-api-client-mef-credentials/efiler_api_test_client_two-20250730224801862900000003-Vjjy68]
module.secrets.module.secrets_manager["efiler-api-client-mef-credentials/efiler_api_test_client"].aws_secretsmanager_secret.this[0]: Refreshing state... [id=arn:aws:secretsmanager:us-east-1:669097061340:secret:efiler-api/demo//efiler-api-client-mef-credentials/efiler_api_test_client-20250730224801862800000001-uh7eM8]
module.vpc.data.aws_subnets.endpoints["ecr.api"]: Reading...
module.vpc.data.aws_subnets.endpoints["ssm-incidents"]: Reading...
module.vpc.data.aws_subnets.endpoints["ec2"]: Reading...
module.vpc.data.aws_subnets.endpoints["guardduty-data"]: Reading...
module.vpc.data.aws_subnets.endpoints["ssm"]: Reading...
module.vpc.data.aws_subnets.endpoints["ssm-incidents"]: Read complete after 0s [id=us-east-1]
module.vpc.data.aws_subnets.endpoints["ssm-contacts"]: Reading...
module.vpc.data.aws_subnets.endpoints["ecr.api"]: Read complete after 0s [id=us-east-1]
module.vpc.data.aws_subnets.endpoints["ecr.dkr"]: Reading...
module.vpc.data.aws_subnets.endpoints["ec2"]: Read complete after 1s [id=us-east-1]
module.vpc.data.aws_subnets.endpoints["ec2messages"]: Reading...
module.vpc.data.aws_subnets.endpoints["guardduty-data"]: Read complete after 1s [id=us-east-1]
module.vpc.data.aws_subnets.endpoints["ssmmessages"]: Reading...
module.vpc.data.aws_subnets.endpoints["ssm"]: Read complete after 1s [id=us-east-1]
module.web.data.aws_vpc.current: Reading...
module.vpc.data.aws_subnets.endpoints["ssm-contacts"]: Read complete after 1s [id=us-east-1]
module.vpc.data.aws_subnets.endpoints["ecr.dkr"]: Read complete after 0s [id=us-east-1]
module.logging.module.s3.data.aws_iam_policy_document.combined: Reading...
module.vpc.module.endpoints.aws_security_group_rule.this["ingress_https"]: Refreshing state... [id=sgrule-1596273785]
module.logging.module.s3.data.aws_iam_policy_document.combined: Read complete after 0s [id=1159658004]
module.logging.aws_kms_alias.logs: Refreshing state... [id=alias/efiler-api/demo/logs]
module.vpc.data.aws_subnets.endpoints["ec2messages"]: Read complete after 0s [id=us-east-1]
module.web.aws_iam_role_policy_attachments_exclusive.execution: Refreshing state...
module.vpc.data.aws_subnets.endpoints["ssmmessages"]: Read complete after 0s [id=us-east-1]
module.web.aws_iam_role_policy_attachments_exclusive.task: Refreshing state...
module.web.aws_iam_policy.execution: Refreshing state... [id=arn:aws:iam::669097061340:policy/efiler-api-demo-web-execution]
module.vpc.module.vpc.aws_nat_gateway.this[2]: Refreshing state... [id=nat-0b8d7666646713235]
module.vpc.module.vpc.aws_nat_gateway.this[0]: Refreshing state... [id=nat-0b769c5115c8fde09]
module.vpc.module.vpc.aws_nat_gateway.this[1]: Refreshing state... [id=nat-05df2ab9747b97ae4]
module.logging.module.s3.aws_s3_bucket_policy.main: Refreshing state... [id=efiler-api-demo-logs]
module.web.module.alb["this"].aws_security_group.this[0]: Refreshing state... [id=sg-0b9650fde174d086a]
module.web.module.alb["this"].aws_lb_target_group.this["endpoint"]: Refreshing state... [id=arn:aws:elasticloadbalancing:us-east-1:669097061340:targetgroup/efiler-api-demo-web-app/23fd32a7a57eb5c8]
module.web.module.task_security_group.aws_security_group.this_name_prefix[0]: Refreshing state... [id=sg-03affc51be83bd973]
module.web.module.endpoint_security_group.aws_security_group.this_name_prefix[0]: Refreshing state... [id=sg-05820d03ba9e44154]
module.secrets.module.secrets_manager["efiler-api-client-mef-credentials/efiler_api_test_client_two"].aws_secretsmanager_secret_version.ignore_changes[0]: Refreshing state... [id=arn:aws:secretsmanager:us-east-1:669097061340:secret:efiler-api/demo//efiler-api-client-mef-credentials/efiler_api_test_client_two-20250730224801862900000003-Vjjy68|terraform-20250730224802182800000005]
module.secrets.module.secrets_manager["efiler-api-client-mef-credentials/efiler_api_test_client"].aws_secretsmanager_secret_version.ignore_changes[0]: Refreshing state... [id=arn:aws:secretsmanager:us-east-1:669097061340:secret:efiler-api/demo//efiler-api-client-mef-credentials/efiler_api_test_client-20250730224801862800000001-uh7eM8|terraform-20250730224802207600000006]
module.logging.module.s3.aws_s3_bucket_lifecycle_configuration.main[0]: Refreshing state... [id=efiler-api-demo-logs]
module.web.aws_cloudwatch_log_group.service: Refreshing state... [id=/aws/ecs/efiler-api/demo/web]
module.vpc.module.vpc.aws_route.private_nat_gateway[0]: Refreshing state... [id=r-rtb-0b6171edd0d71882c1080289494]
module.vpc.module.vpc.aws_route.private_nat_gateway[1]: Refreshing state... [id=r-rtb-043b883fe643054f31080289494]
module.vpc.module.vpc.aws_route.private_nat_gateway[2]: Refreshing state... [id=r-rtb-09c97d313ce6469d61080289494]
module.vpc.module.vpc.aws_cloudwatch_log_group.flow_log[0]: Refreshing state... [id=/aws/vpc-flow-log/vpc-0993eae38281e27a5]
module.vpc.module.endpoints.data.aws_vpc_endpoint_service.this["ec2messages"]: Reading...
module.vpc.module.endpoints.data.aws_vpc_endpoint_service.this["ssm-contacts"]: Reading...
module.vpc.module.endpoints.data.aws_vpc_endpoint_service.this["ssm-incidents"]: Reading...
module.vpc.module.endpoints.data.aws_vpc_endpoint_service.this["ssmmessages"]: Reading...
module.vpc.module.endpoints.data.aws_vpc_endpoint_service.this["ssm"]: Reading...
module.vpc.module.endpoints.data.aws_vpc_endpoint_service.this["ec2messages"]: Read complete after 0s [id=2187510914]
module.vpc.module.endpoints.data.aws_vpc_endpoint_service.this["ecr.dkr"]: Reading...
module.vpc.module.endpoints.data.aws_vpc_endpoint_service.this["ssm-contacts"]: Read complete after 0s [id=3701104373]
module.vpc.module.endpoints.data.aws_vpc_endpoint_service.this["s3"]: Reading...
module.web.data.aws_vpc.current: Read complete after 0s [id=vpc-0993eae38281e27a5]
module.vpc.module.endpoints.data.aws_vpc_endpoint_service.this["ec2"]: Reading...
module.vpc.module.endpoints.data.aws_vpc_endpoint_service.this["ssmmessages"]: Read complete after 0s [id=1315226949]
module.vpc.module.endpoints.data.aws_vpc_endpoint_service.this["ecr.api"]: Reading...
module.vpc.module.endpoints.data.aws_vpc_endpoint_service.this["ssm"]: Read complete after 0s [id=874300523]
module.vpc.module.endpoints.data.aws_vpc_endpoint_service.this["guardduty-data"]: Reading...
module.vpc.module.endpoints.data.aws_vpc_endpoint_service.this["ssm-incidents"]: Read complete after 1s [id=3798321550]
module.web.module.task_security_group.aws_security_group_rule.egress_rules[0]: Refreshing state... [id=sgrule-3096787802]
module.vpc.module.endpoints.data.aws_vpc_endpoint_service.this["ecr.dkr"]: Read complete after 1s [id=1314884315]
module.web.module.endpoint_security_group.aws_security_group_rule.egress_rules[0]: Refreshing state... [id=sgrule-438343391]
module.vpc.module.endpoints.data.aws_vpc_endpoint_service.this["s3"]: Read complete after 1s [id=195798706]
module.web.module.task_security_group.aws_security_group_rule.ingress_with_source_security_group_id[0]: Refreshing state... [id=sgrule-4058955818]
module.vpc.module.endpoints.data.aws_vpc_endpoint_service.this["ec2"]: Read complete after 1s [id=2644592029]
module.web.module.alb["this"].aws_lb.this[0]: Refreshing state... [id=arn:aws:elasticloadbalancing:us-east-1:669097061340:loadbalancer/app/efiler-api-demo-web/b6d5632514aa7002]
module.vpc.module.endpoints.data.aws_vpc_endpoint_service.this["guardduty-data"]: Read complete after 1s [id=3795168285]
module.web.module.endpoint_security_group.aws_security_group_rule.ingress_rules[0]: Refreshing state... [id=sgrule-3675781949]
module.vpc.module.endpoints.data.aws_vpc_endpoint_service.this["ecr.api"]: Read complete after 1s [id=1808222790]
module.web.module.endpoint_security_group.aws_security_group_rule.ingress_rules[1]: Refreshing state... [id=sgrule-720432978]
module.vpc.module.endpoints.aws_vpc_endpoint.this["ecr.dkr"]: Refreshing state... [id=vpce-00c85f2094a139ed8]
module.vpc.module.endpoints.aws_vpc_endpoint.this["ec2"]: Refreshing state... [id=vpce-098ae87b7e7d1a762]
module.vpc.module.endpoints.aws_vpc_endpoint.this["ssm-incidents"]: Refreshing state... [id=vpce-0edd8fca181e7e57c]
module.vpc.module.endpoints.aws_vpc_endpoint.this["s3"]: Refreshing state... [id=vpce-0c3ee0fdc6c994586]
module.vpc.module.endpoints.aws_vpc_endpoint.this["ssm"]: Refreshing state... [id=vpce-01c6aed0543be65fa]
module.vpc.module.endpoints.aws_vpc_endpoint.this["ssm-contacts"]: Refreshing state... [id=vpce-08a480af32757cc18]
module.vpc.module.endpoints.aws_vpc_endpoint.this["ssmmessages"]: Refreshing state... [id=vpce-0b41f00b62e0d0835]
module.vpc.module.endpoints.aws_vpc_endpoint.this["ec2messages"]: Refreshing state... [id=vpce-05553645ec8fa8f52]
module.vpc.module.endpoints.aws_vpc_endpoint.this["ecr.api"]: Refreshing state... [id=vpce-06c2a40f3df5c9611]
module.vpc.module.endpoints.aws_vpc_endpoint.this["guardduty-data"]: Refreshing state... [id=vpce-00cc278b1e044dbc1]
module.web.module.alb["this"].aws_lb_listener.this["http"]: Refreshing state... [id=arn:aws:elasticloadbalancing:us-east-1:669097061340:listener/app/efiler-api-demo-web/b6d5632514aa7002/151b71fd0a9bd6b9]
module.web.module.alb["this"].aws_lb_listener.this["https"]: Refreshing state... [id=arn:aws:elasticloadbalancing:us-east-1:669097061340:listener/app/efiler-api-demo-web/b6d5632514aa7002/b72241b73909911b]
module.vpc.module.vpc.data.aws_iam_policy_document.vpc_flow_log_cloudwatch[0]: Reading...
module.vpc.module.vpc.data.aws_iam_policy_document.vpc_flow_log_cloudwatch[0]: Read complete after 0s [id=1246327674]
module.vpc.module.vpc.aws_flow_log.this[0]: Refreshing state... [id=fl-0c0a1b8e51ed767f3]
module.web.aws_route53_record.endpoint["this"]: Refreshing state... [id=Z02785241R5HD9XU9LQQU_demo.efiler-api.fileyourstatetaxes.org_A]
module.vpc.module.vpc.aws_iam_policy.vpc_flow_log_cloudwatch[0]: Refreshing state... [id=arn:aws:iam::669097061340:policy/vpc-flow-log-to-cloudwatch-20250730213533553500000001]
module.web.module.ecs_service.module.fargate.module.task.aws_ecs_task_definition.main[0]: Refreshing state... [id=efiler-api-demo-web]
module.vpc.module.vpc.aws_iam_role_policy_attachment.vpc_flow_log_cloudwatch[0]: Refreshing state... [id=vpc-flow-log-role-20250730210310507700000001-20250730213533750900000003]
module.web.module.ecs_service.module.fargate.aws_ecs_service.main[0]: Refreshing state... [id=arn:aws:ecs:us-east-1:669097061340:service/efiler-api-demo-web/efiler-api-demo-web]

OpenTofu used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
-/+ destroy and then create replacement

OpenTofu will perform the following actions:

  # module.secrets.module.secrets_manager["efiler-api-client-mef-credentials/efiler_api_test_client"].aws_secretsmanager_secret.this[0] must be replaced
-/+ resource "aws_secretsmanager_secret" "this" {
      ~ arn                            = "arn:aws:secretsmanager:us-east-1:669097061340:secret:efiler-api/demo//efiler-api-client-mef-credentials/efiler_api_test_client-20250730224801862800000001-uh7eM8" -> (known after apply)
      ~ id                             = "arn:aws:secretsmanager:us-east-1:669097061340:secret:efiler-api/demo//efiler-api-client-mef-credentials/efiler_api_test_client-20250730224801862800000001-uh7eM8" -> (known after apply)
      ~ name                           = "efiler-api/demo//efiler-api-client-mef-credentials/efiler_api_test_client-20250730224801862800000001" -> (known after apply)
      ~ name_prefix                    = "efiler-api/demo//efiler-api-client-mef-credentials/efiler_api_test_client-" -> "efiler-api-client-mef-credentials/efiler_api_test_client-" # forces replacement
      + policy                         = (known after apply)
      - tags                           = {} -> null
      ~ tags_all                       = {} -> (known after apply)
        # (4 unchanged attributes hidden)

      ~ replica {
          + arn                            = (known after apply)
          + description                    = (known after apply)
          + force_overwrite_replica_secret = (known after apply)
          + id                             = (known after apply)
          + kms_key_id                     = (known after apply)
          + name                           = (known after apply)
          + name_prefix                    = (known after apply)
          + policy                         = (known after apply)
          + recovery_window_in_days        = (known after apply)
          + tags                           = (known after apply)
          + tags_all                       = (known after apply)
        } -> (known after apply)
    }

  # module.secrets.module.secrets_manager["efiler-api-client-mef-credentials/efiler_api_test_client"].aws_secretsmanager_secret_version.ignore_changes[0] must be replaced
-/+ resource "aws_secretsmanager_secret_version" "ignore_changes" {
      ~ arn                  = "arn:aws:secretsmanager:us-east-1:669097061340:secret:efiler-api/demo//efiler-api-client-mef-credentials/efiler_api_test_client-20250730224801862800000001-uh7eM8" -> (known after apply)
      + has_secret_string_wo = (known after apply)
      ~ id                   = "arn:aws:secretsmanager:us-east-1:669097061340:secret:efiler-api/demo//efiler-api-client-mef-credentials/efiler_api_test_client-20250730224801862800000001-uh7eM8|terraform-20250730224802207600000006" -> (known after apply)
      ~ secret_id            = "arn:aws:secretsmanager:us-east-1:669097061340:secret:efiler-api/demo//efiler-api-client-mef-credentials/efiler_api_test_client-20250730224801862800000001-uh7eM8" # forces replacement -> (known after apply) # forces replacement
      ~ version_id           = "terraform-20250730224802207600000006" -> (known after apply)
      ~ version_stages       = [
          - "AWSCURRENT",
        ] -> (known after apply)
        # (1 unchanged attribute hidden)
    }

  # module.secrets.module.secrets_manager["efiler-api-client-mef-credentials/efiler_api_test_client_two"].aws_secretsmanager_secret.this[0] must be replaced
-/+ resource "aws_secretsmanager_secret" "this" {
      ~ arn                            = "arn:aws:secretsmanager:us-east-1:669097061340:secret:efiler-api/demo//efiler-api-client-mef-credentials/efiler_api_test_client_two-20250730224801862900000003-Vjjy68" -> (known after apply)
      ~ id                             = "arn:aws:secretsmanager:us-east-1:669097061340:secret:efiler-api/demo//efiler-api-client-mef-credentials/efiler_api_test_client_two-20250730224801862900000003-Vjjy68" -> (known after apply)
      ~ name                           = "efiler-api/demo//efiler-api-client-mef-credentials/efiler_api_test_client_two-20250730224801862900000003" -> (known after apply)
      ~ name_prefix                    = "efiler-api/demo//efiler-api-client-mef-credentials/efiler_api_test_client_two-" -> "efiler-api-client-mef-credentials/efiler_api_test_client_two-" # forces replacement
      + policy                         = (known after apply)
      - tags                           = {} -> null
      ~ tags_all                       = {} -> (known after apply)
        # (4 unchanged attributes hidden)

      ~ replica {
          + arn                            = (known after apply)
          + description                    = (known after apply)
          + force_overwrite_replica_secret = (known after apply)
          + id                             = (known after apply)
          + kms_key_id                     = (known after apply)
          + name                           = (known after apply)
          + name_prefix                    = (known after apply)
          + policy                         = (known after apply)
          + recovery_window_in_days        = (known after apply)
          + tags                           = (known after apply)
          + tags_all                       = (known after apply)
        } -> (known after apply)
    }

  # module.secrets.module.secrets_manager["efiler-api-client-mef-credentials/efiler_api_test_client_two"].aws_secretsmanager_secret_version.ignore_changes[0] must be replaced
-/+ resource "aws_secretsmanager_secret_version" "ignore_changes" {
      ~ arn                  = "arn:aws:secretsmanager:us-east-1:669097061340:secret:efiler-api/demo//efiler-api-client-mef-credentials/efiler_api_test_client_two-20250730224801862900000003-Vjjy68" -> (known after apply)
      + has_secret_string_wo = (known after apply)
      ~ id                   = "arn:aws:secretsmanager:us-east-1:669097061340:secret:efiler-api/demo//efiler-api-client-mef-credentials/efiler_api_test_client_two-20250730224801862900000003-Vjjy68|terraform-20250730224802182800000005" -> (known after apply)
      ~ secret_id            = "arn:aws:secretsmanager:us-east-1:669097061340:secret:efiler-api/demo//efiler-api-client-mef-credentials/efiler_api_test_client_two-20250730224801862900000003-Vjjy68" # forces replacement -> (known after apply) # forces replacement
      ~ version_id           = "terraform-20250730224802182800000005" -> (known after apply)
      ~ version_stages       = [
          - "AWSCURRENT",
        ] -> (known after apply)
        # (1 unchanged attribute hidden)
    }

Plan: 4 to add, 0 to change, 4 to destroy.

─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────

Saved the plan to: tfplan.out

To perform exactly these actions, run the following command to apply:
    tofu apply "tfplan.out"
```