### PR TITLE
[FYST-2222] Update fargate module to 1.5.0 to ensure we don't create ECR repository for worker module

### DIFF
--- a/tofu/modules/pya/main.tf
+++ b/tofu/modules/pya/main.tf
@@ -95,7 +95,7 @@ module "vpc" {
 }
 
 module "web" {
-  source = "github.com/codeforamerica/tofu-modules-aws-fargate-service?ref=1.2.0"
+  source = "github.com/codeforamerica/tofu-modules-aws-fargate-service?ref=1.5.0"
 
   project       = "pya"
   project_short = "pya"
@@ -141,7 +141,7 @@ module "web" {
 }
 
 module "workers" {
-  source = "github.com/codeforamerica/tofu-modules-aws-fargate-service?ref=1.2.0"
+  source = "github.com/codeforamerica/tofu-modules-aws-fargate-service?ref=1.5.0"
 
   project       = "pya"
   project_short = "pya"
@@ -157,6 +157,7 @@ module "workers" {
   version_parameter = module.web.version_parameter
   image_url = module.web.repository_url
   create_endpoint = false
+  create_repository = false
   enable_execute_command = true
 
   execution_policies = [aws_iam_policy.ecs_s3_access.arn]


### PR DESCRIPTION
[prod changes](https://gist.github.com/arinchoi03/923bbe136924869096efe4e7caf0d4b0)
[staging changes](https://gist.github.com/arinchoi03/9120289eb6f5a88220518242f762f015)

Thread for context: https://cfastaff.slack.com/archives/C091WA2RZC0/p1754348248156379?thread_ts=1754342036.865229&cid=C091WA2RZC0

The worker should use the same image as the webapp, therefore with this change we are pointing the worker module to the existing web image. If we `create_repository` :

`  image_url      = var.create_repository ? module.ecr["this"].repository_url : var.image_url` -- we want to use `image_url` for the worker

however, we ran into this issue:
```
╷
│ Error: Invalid index
│
│   on .terraform/modules/pya.workers/outputs.tf line 23, in output "repository_url":
│   23:   value       = module.ecr["this"].repository_url
│     ├────────────────
│     │ module.ecr is object with no attributes
│
│ The given key does not identify an element in this collection value.
╵
```

by simply making the `create_repository` value `false`. Upgrading to fargate 1.5.0 (instead of version 1.2.0 we were on) seems to address the issue.