### PR TITLE
[TBE-191] Add Bastion Module to demo efiler-api

### DIFF
--- a/tofu/config/demo.efilerapi.org/main.tf
+++ b/tofu/config/demo.efilerapi.org/main.tf
@@ -54,3 +54,13 @@ module "web" {
   public = false
   enable_execute_command = true
 }
+
+module "bastion" {
+  source = "github.com/codeforamerica/tofu-modules-aws-ssm-bastion?ref=1.0.0"
+
+  project            = "efiler-api"
+  environment        = "demo"
+  key_pair_name      = "efiler-api-demo-bastion"
+  private_subnet_ids = module.vpc.private_subnets
+  vpc_id             = module.vpc.vpc_id
+}


### PR DESCRIPTION
```

OpenTofu will perform the following actions:

  # module.bastion.aws_instance.this will be created
  + resource "aws_instance" "this" {
      + ami                                  = "ami-08a6efd148b1f7504"
      + arn                                  = (known after apply)
      + associate_public_ip_address          = false
      + availability_zone                    = (known after apply)
      + cpu_core_count                       = (known after apply)
      + cpu_threads_per_core                 = (known after apply)
      + disable_api_stop                     = (known after apply)
      + disable_api_termination              = (known after apply)
      + ebs_optimized                        = (known after apply)
      + enable_primary_ipv6                  = (known after apply)
      + get_password_data                    = false
      + host_id                              = (known after apply)
      + host_resource_group_arn              = (known after apply)
      + iam_instance_profile                 = "AmazonSSMRoleForInstancesQuickSetup"
      + id                                   = (known after apply)
      + instance_initiated_shutdown_behavior = (known after apply)
      + instance_lifecycle                   = (known after apply)
      + instance_state                       = (known after apply)
      + instance_type                        = "t2.micro"
      + ipv6_address_count                   = (known after apply)
      + ipv6_addresses                       = (known after apply)
      + key_name                             = "efiler-api-demo-bastion"
      + monitoring                           = true
      + outpost_arn                          = (known after apply)
      + password_data                        = (known after apply)
      + placement_group                      = (known after apply)
      + placement_partition_number           = (known after apply)
      + primary_network_interface_id         = (known after apply)
      + private_dns                          = (known after apply)
      + private_ip                           = (known after apply)
      + public_dns                           = (known after apply)
      + public_ip                            = (known after apply)
      + secondary_private_ips                = (known after apply)
      + security_groups                      = (known after apply)
      + source_dest_check                    = true
      + spot_instance_request_id             = (known after apply)
      + subnet_id                            = (known after apply)
      + tags                                 = {
          + "Name"    = "efiler-api-demo-bastion"
          + "service" = "bastion"
        }
      + tags_all                             = {
          + "Name"    = "efiler-api-demo-bastion"
          + "service" = "bastion"
        }
      + tenancy                              = (known after apply)
      + user_data                            = (known after apply)
      + user_data_base64                     = (known after apply)
      + user_data_replace_on_change          = false
      + volume_tags                          = {
          + "service" = "bastion"
        }
      + vpc_security_group_ids               = (known after apply)

      + capacity_reservation_specification (known after apply)

      + cpu_options (known after apply)

      + ebs_block_device (known after apply)

      + enclave_options (known after apply)

      + ephemeral_block_device (known after apply)

      + instance_market_options (known after apply)

      + maintenance_options (known after apply)

      + metadata_options {
          + http_endpoint               = "enabled"
          + http_protocol_ipv6          = "disabled"
          + http_put_response_hop_limit = (known after apply)
          + http_tokens                 = "required"
          + instance_metadata_tags      = (known after apply)
        }

      + network_interface (known after apply)

      + private_dns_name_options (known after apply)

      + root_block_device {
          + delete_on_termination = true
          + device_name           = (known after apply)
          + encrypted             = true
          + iops                  = (known after apply)
          + kms_key_id            = (known after apply)
          + tags_all              = (known after apply)
          + throughput            = (known after apply)
          + volume_id             = (known after apply)
          + volume_size           = 10
          + volume_type           = (known after apply)
        }
    }

  # module.bastion.aws_kms_alias.this will be created
  + resource "aws_kms_alias" "this" {
      + arn            = (known after apply)
      + id             = (known after apply)
      + name           = "alias/efiler-api/demo/bastion"
      + name_prefix    = (known after apply)
      + target_key_arn = (known after apply)
      + target_key_id  = (known after apply)
    }

  # module.bastion.aws_kms_key.this will be created
  + resource "aws_kms_key" "this" {
      + arn                                = (known after apply)
      + bypass_policy_lockout_safety_check = false
      + customer_master_key_spec           = "SYMMETRIC_DEFAULT"
      + deletion_window_in_days            = 30
      + description                        = "Bastion host encryption key for efiler-api demo"
      + enable_key_rotation                = true
      + id                                 = (known after apply)
      + is_enabled                         = true
      + key_id                             = (known after apply)
      + key_usage                          = "ENCRYPT_DECRYPT"
      + multi_region                       = (known after apply)
      + policy                             = jsonencode(
            {
              + Id        = "Bastion host key policy"
              + Statement = [
                  + {
                      + Action    = "kms:*"
                      + Effect    = "Allow"
                      + Principal = {
                          + AWS = "arn:aws:iam::669097061340:root"
                        }
                      + Resource  = "*"
                      + Sid       = "Enable IAM User Permissions"
                    },
                  + {
                      + Action    = [
                          + "kms:Encrypt",
                          + "kms:Decrypt",
                          + "kms:ReEncrypt*",
                          + "kms:GenerateDataKey*",
                          + "kms:CreateGrant",
                          + "kms:DescribeKey",
                        ]
                      + Condition = {
                          + StringEquals = {
                              + "kms:CallerAccount" = "669097061340"
                              + "kms:ViaService"    = "ec2.us-east-1.amazonaws.com"
                            }
                        }
                      + Effect    = "Allow"
                      + Principal = {
                          + AWS = "*"
                        }
                      + Resource  = "*"
                      + Sid       = "Allow access through EBS for all principals in the account that are authorized to use EBS"
                    },
                  + {
                      + Action    = [
                          + "kms:Describe*",
                          + "kms:Get*",
                          + "kms:List*",
                          + "kms:RevokeGrant",
                        ]
                      + Effect    = "Allow"
                      + Principal = {
                          + AWS = "arn:aws:iam::669097061340:root"
                        }
                      + Resource  = "*"
                      + Sid       = "Allow direct access to key metadata to the account"
                    },
                ]
              + Version   = "2012-10-17"
            }
        )
      + rotation_period_in_days            = (known after apply)
      + tags                               = {
          + "service" = "bastion"
        }
      + tags_all                           = {
          + "service" = "bastion"
        }
    }

  # module.bastion.random_shuffle.subnet will be created
  + resource "random_shuffle" "subnet" {
      + id           = (known after apply)
      + input        = [
          + "subnet-0d0a4c290054abff4",
          + "subnet-0677be647cf23fecd",
          + "subnet-05904735ca7c78827",
        ]
      + result       = (known after apply)
      + result_count = 1
    }

  # module.bastion.module.security_group.aws_security_group.this_name_prefix[0] will be created
  + resource "aws_security_group" "this_name_prefix" {
      + arn                    = (known after apply)
      + description            = "Security Group managed by Terraform"
      + egress                 = (known after apply)
      + id                     = (known after apply)
      + ingress                = (known after apply)
      + name                   = (known after apply)
      + name_prefix            = "efiler-api-demo-bastion-"
      + owner_id               = (known after apply)
      + revoke_rules_on_delete = false
      + tags                   = {
          + "Name"    = "efiler-api-demo-bastion"
          + "service" = "bastion"
        }
      + tags_all               = {
          + "Name"    = "efiler-api-demo-bastion"
          + "service" = "bastion"
        }
      + vpc_id                 = "vpc-0993eae38281e27a5"

      + timeouts {
          + create = "10m"
          + delete = "15m"
        }
    }

  # module.bastion.module.security_group.aws_security_group_rule.egress_rules[0] will be created
  + resource "aws_security_group_rule" "egress_rules" {
      + cidr_blocks              = [
          + "0.0.0.0/0",
        ]
      + description              = "All protocols"
      + from_port                = -1
      + id                       = (known after apply)
      + ipv6_cidr_blocks         = [
          + "::/0",
        ]
      + prefix_list_ids          = []
      + protocol                 = "-1"
      + security_group_id        = (known after apply)
      + security_group_rule_id   = (known after apply)
      + self                     = false
      + source_security_group_id = (known after apply)
      + to_port                  = -1
      + type                     = "egress"
    }

Plan: 6 to add, 0 to change, 0 to destroy.
```