### PR TITLE
Take out unnecessary region env variable for efiler-api

### DIFF
--- a/tofu/config/demo.efilerapi.org/main.tf
+++ b/tofu/config/demo.efilerapi.org/main.tf
@@ -55,10 +55,6 @@ module "web" {
   enable_execute_command = true
 
   task_policies = ["arn:aws:iam::669097061340:policy/efiler-api-client-mef-credentials-access"]
-
-  environment_variables = {
-    AWS_REGION = "us-east-1"
-  }
 }
 
 module "bastion" {


### PR DESCRIPTION
OpenTofu will perform the following actions:
```
  # module.web.module.ecs_service.module.fargate.aws_ecs_service.main[0] will be updated in-place
  ~ resource "aws_ecs_service" "main" {
        id                                 = "arn:aws:ecs:us-east-1:669097061340:service/efiler-api-demo-web/efiler-api-demo-web"
        name                               = "efiler-api-demo-web"
        tags                               = {}
      ~ task_definition                    = "arn:aws:ecs:us-east-1:669097061340:task-definition/efiler-api-demo-web:8" -> (known after apply)
        # (16 unchanged attributes hidden)

        # (4 unchanged blocks hidden)
    }

  # module.web.module.ecs_service.module.fargate.module.task.aws_ecs_task_definition.main[0] must be replaced
+/- resource "aws_ecs_task_definition" "main" {
      ~ arn                      = "arn:aws:ecs:us-east-1:669097061340:task-definition/efiler-api-demo-web:8" -> (known after apply)
      ~ arn_without_revision     = "arn:aws:ecs:us-east-1:669097061340:task-definition/efiler-api-demo-web" -> (known after apply)
      ~ container_definitions    = jsonencode(
          ~ [
              ~ {
                  - environment       = [
                      - {
                          - name  = "AWS_REGION"
                          - value = "us-east-1"
                        },
                    ]
                  - mountPoints       = []
                    name              = "efiler-api-demo-web"
                  ~ portMappings      = [
                      ~ {
                          - hostPort      = 4567
                          - protocol      = "tcp"
                            # (1 unchanged attribute hidden)
                        },
                    ]
                  - systemControls    = []
                  - volumesFrom       = []
                    # (7 unchanged attributes hidden)
                },
              ~ {
                  - mountPoints      = []
                    name             = "otel-collector"
                  - portMappings     = []
                  - systemControls   = []
                  - volumesFrom      = []
                    # (8 unchanged attributes hidden)
                },
            ] # forces replacement
        )
      ~ enable_fault_injection   = false -> (known after apply)
      ~ id                       = "efiler-api-demo-web" -> (known after apply)
      ~ revision                 = 8 -> (known after apply)
      - tags                     = {} -> null
      ~ tags_all                 = {} -> (known after apply)
        # (9 unchanged attributes hidden)
    }

Plan: 1 to add, 1 to change, 1 to destroy.
```