### PR TITLE
remove execution policies from efiler api since they aren't the right approach

### DIFF
--- a/tofu/config/demo.efilerapi.org/main.tf
+++ b/tofu/config/demo.efilerapi.org/main.tf
@@ -55,7 +55,6 @@ module "web" {
   enable_execute_command = true
 
   task_policies = ["arn:aws:iam::669097061340:policy/efiler-api-client-mef-credentials-access"]
-  execution_policies = ["arn:aws:iam::669097061340:policy/efiler-api-client-mef-credentials-access"]
 }
 
 module "bastion" {


### PR DESCRIPTION
```
OpenTofu used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  ~ update in-place

OpenTofu will perform the following actions:

  # module.web.aws_iam_role_policy_attachments_exclusive.execution will be updated in-place
  ~ resource "aws_iam_role_policy_attachments_exclusive" "execution" {
      ~ policy_arns = [
          - "arn:aws:iam::669097061340:policy/efiler-api-client-mef-credentials-access",
            # (3 unchanged elements hidden)
        ]
        # (1 unchanged attribute hidden)
    }

Plan: 0 to add, 1 to change, 0 to destroy.
```