### PR TITLE
Add secret key base & switch to rails port from sinatra's

### DIFF
--- a/tofu/config/demo.efilerapi.org/main.tf
+++ b/tofu/config/demo.efilerapi.org/main.tf
@@ -47,7 +47,7 @@ module "web" {
   private_subnets = module.vpc.private_subnets
   public_subnets  = module.vpc.public_subnets
   logging_key_id  = module.logging.kms_key_arn
-  container_port  = 4567
+  container_port  = 80
   create_endpoint = true
   create_repository   = true
   create_version_parameter = true


### PR DESCRIPTION
```
OpenTofu used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  ~ update in-place
-/+ destroy and then create replacement
+/- create replacement and then destroy

OpenTofu will perform the following actions:

  # module.web.aws_iam_policy.secrets will be updated in-place
  ~ resource "aws_iam_policy" "secrets" {
        id               = "arn:aws:iam::669097061340:policy/efiler-api-demo-web-secrets-access-20250730210320585900000003"
        name             = "efiler-api-demo-web-secrets-access-20250730210320585900000003"
      ~ policy           = jsonencode(
          ~ {
              ~ Statement = [
                  ~ {
                      ~ Resource = [
                            # (1 unchanged element hidden)
                            "arn:aws:ssm:us-east-1:669097061340:parameter/efiler-api/demo/web/otel",
                          + "arn:aws:secretsmanager:us-east-1:669097061340:secret:rails_secret_key_base-h1ygaE",
                        ]
                        # (2 unchanged attributes hidden)
                    },
                ]
                # (1 unchanged attribute hidden)
            }
        )
        tags             = {}
        # (7 unchanged attributes hidden)
    }

  # module.web.module.alb["this"].aws_lb_listener.this["https"] will be updated in-place
  ~ resource "aws_lb_listener" "this" {
        id                                   = "arn:aws:elasticloadbalancing:us-east-1:669097061340:listener/app/efiler-api-demo-web/b6d5632514aa7002/b72241b73909911b"
        tags                                 = {
            "terraform-aws-modules" = "alb"
        }
        # (8 unchanged attributes hidden)

      ~ default_action {
          ~ target_group_arn = "arn:aws:elasticloadbalancing:us-east-1:669097061340:targetgroup/efiler-api-demo-web-app/23fd32a7a57eb5c8" -> (known after apply)
            # (2 unchanged attributes hidden)
        }

        # (1 unchanged block hidden)
    }

  # module.web.module.alb["this"].aws_lb_target_group.this["endpoint"] must be replaced
+/- resource "aws_lb_target_group" "this" {
      ~ arn                                = "arn:aws:elasticloadbalancing:us-east-1:669097061340:targetgroup/efiler-api-demo-web-app/23fd32a7a57eb5c8" -> (known after apply)
      ~ arn_suffix                         = "targetgroup/efiler-api-demo-web-app/23fd32a7a57eb5c8" -> (known after apply)
      + connection_termination             = (known after apply)
      ~ id                                 = "arn:aws:elasticloadbalancing:us-east-1:669097061340:targetgroup/efiler-api-demo-web-app/23fd32a7a57eb5c8" -> (known after apply)
      ~ ip_address_type                    = "ipv4" -> (known after apply)
      ~ load_balancer_arns                 = [
          - "arn:aws:elasticloadbalancing:us-east-1:669097061340:loadbalancer/app/efiler-api-demo-web/b6d5632514aa7002",
        ] -> (known after apply)
      ~ load_balancing_algorithm_type      = "round_robin" -> (known after apply)
      ~ load_balancing_anomaly_mitigation  = "off" -> (known after apply)
      ~ load_balancing_cross_zone_enabled  = "use_load_balancer_configuration" -> (known after apply)
        name                               = "efiler-api-demo-web-app"
      + name_prefix                        = (known after apply)
      ~ port                               = 4567 -> 80 # forces replacement
      + preserve_client_ip                 = (known after apply)
      ~ protocol_version                   = "HTTP1" -> (known after apply)
        tags                               = {
            "terraform-aws-modules" = "alb"
        }
        # (8 unchanged attributes hidden)

      ~ health_check {
          ~ matcher             = "200" -> (known after apply)
          ~ timeout             = 5 -> (known after apply)
            # (7 unchanged attributes hidden)
        }

      ~ stickiness {
          + arn                                = (known after apply)
          + arn_suffix                         = (known after apply)
          + connection_termination             = (known after apply)
          + deregistration_delay               = (known after apply)
          + id                                 = (known after apply)
          + ip_address_type                    = (known after apply)
          + lambda_multi_value_headers_enabled = (known after apply)
          + load_balancer_arns                 = (known after apply)
          + load_balancing_algorithm_type      = (known after apply)
          + load_balancing_anomaly_mitigation  = (known after apply)
          + load_balancing_cross_zone_enabled  = (known after apply)
          + name                               = (known after apply)
          + name_prefix                        = (known after apply)
          + port                               = (known after apply)
          + preserve_client_ip                 = (known after apply)
          + protocol                           = (known after apply)
          + protocol_version                   = (known after apply)
          + proxy_protocol_v2                  = (known after apply)
          + slow_start                         = (known after apply)
          + tags                               = (known after apply)
          + tags_all                           = (known after apply)
          + target_type                        = (known after apply)
          + vpc_id                             = (known after apply)
        } -> (known after apply)

      ~ target_failover {
          + arn                                = (known after apply)
          + arn_suffix                         = (known after apply)
          + connection_termination             = (known after apply)
          + deregistration_delay               = (known after apply)
          + id                                 = (known after apply)
          + ip_address_type                    = (known after apply)
          + lambda_multi_value_headers_enabled = (known after apply)
          + load_balancer_arns                 = (known after apply)
          + load_balancing_algorithm_type      = (known after apply)
          + load_balancing_anomaly_mitigation  = (known after apply)
          + load_balancing_cross_zone_enabled  = (known after apply)
          + name                               = (known after apply)
          + name_prefix                        = (known after apply)
          + port                               = (known after apply)
          + preserve_client_ip                 = (known after apply)
          + protocol                           = (known after apply)
          + protocol_version                   = (known after apply)
          + proxy_protocol_v2                  = (known after apply)
          + slow_start                         = (known after apply)
          + tags                               = (known after apply)
          + tags_all                           = (known after apply)
          + target_type                        = (known after apply)
          + vpc_id                             = (known after apply)
        } -> (known after apply)

      ~ target_group_health {
          + arn                                = (known after apply)
          + arn_suffix                         = (known after apply)
          + connection_termination             = (known after apply)
          + deregistration_delay               = (known after apply)
          + id                                 = (known after apply)
          + ip_address_type                    = (known after apply)
          + lambda_multi_value_headers_enabled = (known after apply)
          + load_balancer_arns                 = (known after apply)
          + load_balancing_algorithm_type      = (known after apply)
          + load_balancing_anomaly_mitigation  = (known after apply)
          + load_balancing_cross_zone_enabled  = (known after apply)
          + name                               = (known after apply)
          + name_prefix                        = (known after apply)
          + port                               = (known after apply)
          + preserve_client_ip                 = (known after apply)
          + protocol                           = (known after apply)
          + protocol_version                   = (known after apply)
          + proxy_protocol_v2                  = (known after apply)
          + slow_start                         = (known after apply)
          + tags                               = (known after apply)
          + tags_all                           = (known after apply)
          + target_type                        = (known after apply)
          + vpc_id                             = (known after apply)
        } -> (known after apply)

      ~ target_health_state {
          + arn                                = (known after apply)
          + arn_suffix                         = (known after apply)
          + connection_termination             = (known after apply)
          + deregistration_delay               = (known after apply)
          + id                                 = (known after apply)
          + ip_address_type                    = (known after apply)
          + lambda_multi_value_headers_enabled = (known after apply)
          + load_balancer_arns                 = (known after apply)
          + load_balancing_algorithm_type      = (known after apply)
          + load_balancing_anomaly_mitigation  = (known after apply)
          + load_balancing_cross_zone_enabled  = (known after apply)
          + name                               = (known after apply)
          + name_prefix                        = (known after apply)
          + port                               = (known after apply)
          + preserve_client_ip                 = (known after apply)
          + protocol                           = (known after apply)
          + protocol_version                   = (known after apply)
          + proxy_protocol_v2                  = (known after apply)
          + slow_start                         = (known after apply)
          + tags                               = (known after apply)
          + tags_all                           = (known after apply)
          + target_type                        = (known after apply)
          + vpc_id                             = (known after apply)
        } -> (known after apply)
    }

  # module.web.module.task_security_group.aws_security_group_rule.ingress_with_source_security_group_id[0] must be replaced
-/+ resource "aws_security_group_rule" "ingress_with_source_security_group_id" {
      ~ from_port                = 4567 -> 80 # forces replacement
      ~ id                       = "sgrule-4058955818" -> (known after apply)
      ~ security_group_rule_id   = "sgr-09a4a23dc735715af" -> (known after apply)
      ~ to_port                  = 4567 -> 80 # forces replacement
        # (7 unchanged attributes hidden)
    }

  # module.web.module.ecs_service.module.fargate.aws_ecs_service.main[0] will be updated in-place
  ~ resource "aws_ecs_service" "main" {
        id                                 = "arn:aws:ecs:us-east-1:669097061340:service/efiler-api-demo-web/efiler-api-demo-web"
        name                               = "efiler-api-demo-web"
        tags                               = {}
      ~ task_definition                    = "arn:aws:ecs:us-east-1:669097061340:task-definition/efiler-api-demo-web:18" -> (known after apply)
        # (16 unchanged attributes hidden)

      ~ load_balancer {
          + availability_zone_rebalancing      = (known after apply)
          + cluster                            = (known after apply)
          + deployment_maximum_percent         = (known after apply)
          + deployment_minimum_healthy_percent = (known after apply)
          + desired_count                      = (known after apply)
          + enable_ecs_managed_tags            = (known after apply)
          + enable_execute_command             = (known after apply)
          + force_delete                       = (known after apply)
          + force_new_deployment               = (known after apply)
          + health_check_grace_period_seconds  = (known after apply)
          + iam_role                           = (known after apply)
          + id                                 = (known after apply)
          + launch_type                        = (known after apply)
          + name                               = (known after apply)
          + platform_version                   = (known after apply)
          + propagate_tags                     = (known after apply)
          + scheduling_strategy                = (known after apply)
          + tags                               = (known after apply)
          + tags_all                           = (known after apply)
          + task_definition                    = (known after apply)
          + triggers                           = (known after apply)
          + wait_for_steady_state              = (known after apply)
        } -> (known after apply)

        # (3 unchanged blocks hidden)
    }

  # module.web.module.ecs_service.module.fargate.module.task.aws_ecs_task_definition.main[0] must be replaced
+/- resource "aws_ecs_task_definition" "main" {
      ~ arn                      = "arn:aws:ecs:us-east-1:669097061340:task-definition/efiler-api-demo-web:18" -> (known after apply)
      ~ arn_without_revision     = "arn:aws:ecs:us-east-1:669097061340:task-definition/efiler-api-demo-web" -> (known after apply)
      ~ container_definitions    = jsonencode(
          ~ [
              ~ {
                  - mountPoints       = []
                    name              = "efiler-api-demo-web"
                  ~ portMappings      = [
                      ~ {
                          ~ containerPort = 4567 -> 80
                          - hostPort      = 4567
                          - protocol      = "tcp"
                        },
                    ]
                  + secrets           = [
                      + {
                          + name      = "SECRET_KEY_BASE"
                          + valueFrom = "arn:aws:secretsmanager:us-east-1:669097061340:secret:rails_secret_key_base-h1ygaE:key::"
                        },
                    ]
                  - systemControls    = []
                  - volumesFrom       = []
                    # (8 unchanged attributes hidden)
                },
              ~ {
                  - mountPoints      = []
                    name             = "otel-collector"
                  - portMappings     = []
                  - systemControls   = []
                  - volumesFrom      = []
                    # (8 unchanged attributes hidden)
                },
            ] # forces replacement
        )
      ~ enable_fault_injection   = false -> (known after apply)
      ~ id                       = "efiler-api-demo-web" -> (known after apply)
      ~ revision                 = 18 -> (known after apply)
      - tags                     = {} -> null
      ~ tags_all                 = {} -> (known after apply)
        # (9 unchanged attributes hidden)
    }

Plan: 3 to add, 3 to change, 3 to destroy.
```