### PR TITLE
Add the new flag to the efiler API web module so that its ALB will use the port suffix in its name

### DIFF
--- a/tofu/config/demo.efilerapi.org/main.tf
+++ b/tofu/config/demo.efilerapi.org/main.tf
@@ -34,7 +34,7 @@ module "vpc" {
 }
 
 module "web" {
-  source = "github.com/codeforamerica/tofu-modules-aws-fargate-service?ref=1.2.0"
+  source = "github.com/codeforamerica/tofu-modules-aws-fargate-service?ref=1.6.0"
 
   project       = "efiler-api"
   project_short = "efiler-api"
@@ -53,6 +53,7 @@ module "web" {
   create_version_parameter = true
   public = false
   enable_execute_command = true
+  use_target_group_port_suffix = true
 
   # This has an ARN specified manually until we decide to make the secrets module work without adding suffices to the secret names
   task_policies = ["arn:aws:iam::669097061340:policy/efiler-api-client-mef-credentials-access"]


### PR DESCRIPTION
```

OpenTofu used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  ~ update in-place
+/- create replacement and then destroy

OpenTofu will perform the following actions:

  # module.web.module.alb["this"].aws_lb_listener.this["https"] will be updated in-place
  ~ resource "aws_lb_listener" "this" {
        id                                   = "arn:aws:elasticloadbalancing:us-east-1:669097061340:listener/app/efiler-api-demo-web/b6d5632514aa7002/b72241b73909911b"
        tags                                 = {
            "terraform-aws-modules" = "alb"
        }
        # (8 unchanged attributes hidden)

      ~ default_action {
          ~ target_group_arn = "arn:aws:elasticloadbalancing:us-east-1:669097061340:targetgroup/efiler-api-demo-web-app/23fd32a7a57eb5c8" -> (known after apply)
            # (2 unchanged attributes hidden)
        }

        # (1 unchanged block hidden)
    }

  # module.web.module.alb["this"].aws_lb_target_group.this["endpoint"] must be replaced
+/- resource "aws_lb_target_group" "this" {
      ~ arn                                = "arn:aws:elasticloadbalancing:us-east-1:669097061340:targetgroup/efiler-api-demo-web-app/23fd32a7a57eb5c8" -> (known after apply)
      ~ arn_suffix                         = "targetgroup/efiler-api-demo-web-app/23fd32a7a57eb5c8" -> (known after apply)
      + connection_termination             = (known after apply)
      ~ id                                 = "arn:aws:elasticloadbalancing:us-east-1:669097061340:targetgroup/efiler-api-demo-web-app/23fd32a7a57eb5c8" -> (known after apply)
      ~ ip_address_type                    = "ipv4" -> (known after apply)
      ~ load_balancer_arns                 = [
          - "arn:aws:elasticloadbalancing:us-east-1:669097061340:loadbalancer/app/efiler-api-demo-web/b6d5632514aa7002",
        ] -> (known after apply)
      ~ load_balancing_algorithm_type      = "round_robin" -> (known after apply)
      ~ load_balancing_anomaly_mitigation  = "off" -> (known after apply)
      ~ load_balancing_cross_zone_enabled  = "use_load_balancer_configuration" -> (known after apply)
      ~ name                               = "efiler-api-demo-web-app" -> "efiler-api-demo-web-80" # forces replacement
      + name_prefix                        = (known after apply)
      ~ port                               = 4567 -> 80 # forces replacement
      + preserve_client_ip                 = (known after apply)
      ~ protocol_version                   = "HTTP1" -> (known after apply)
        tags                               = {
            "terraform-aws-modules" = "alb"
        }
        # (8 unchanged attributes hidden)

      ~ health_check {
          ~ matcher             = "200" -> (known after apply)
          ~ timeout             = 5 -> (known after apply)
            # (7 unchanged attributes hidden)
        }

      ~ stickiness {
          + arn                                = (known after apply)
          + arn_suffix                         = (known after apply)
          + connection_termination             = (known after apply)
          + deregistration_delay               = (known after apply)
          + id                                 = (known after apply)
          + ip_address_type                    = (known after apply)
          + lambda_multi_value_headers_enabled = (known after apply)
          + load_balancer_arns                 = (known after apply)
          + load_balancing_algorithm_type      = (known after apply)
          + load_balancing_anomaly_mitigation  = (known after apply)
          + load_balancing_cross_zone_enabled  = (known after apply)
          + name                               = (known after apply)
          + name_prefix                        = (known after apply)
          + port                               = (known after apply)
          + preserve_client_ip                 = (known after apply)
          + protocol                           = (known after apply)
          + protocol_version                   = (known after apply)
          + proxy_protocol_v2                  = (known after apply)
          + slow_start                         = (known after apply)
          + tags                               = (known after apply)
          + tags_all                           = (known after apply)
          + target_type                        = (known after apply)
          + vpc_id                             = (known after apply)
        } -> (known after apply)

      ~ target_failover {
          + arn                                = (known after apply)
          + arn_suffix                         = (known after apply)
          + connection_termination             = (known after apply)
          + deregistration_delay               = (known after apply)
          + id                                 = (known after apply)
          + ip_address_type                    = (known after apply)
          + lambda_multi_value_headers_enabled = (known after apply)
          + load_balancer_arns                 = (known after apply)
          + load_balancing_algorithm_type      = (known after apply)
          + load_balancing_anomaly_mitigation  = (known after apply)
          + load_balancing_cross_zone_enabled  = (known after apply)
          + name                               = (known after apply)
          + name_prefix                        = (known after apply)
          + port                               = (known after apply)
          + preserve_client_ip                 = (known after apply)
          + protocol                           = (known after apply)
          + protocol_version                   = (known after apply)
          + proxy_protocol_v2                  = (known after apply)
          + slow_start                         = (known after apply)
          + tags                               = (known after apply)
          + tags_all                           = (known after apply)
          + target_type                        = (known after apply)
          + vpc_id                             = (known after apply)
        } -> (known after apply)

      ~ target_group_health {
          + arn                                = (known after apply)
          + arn_suffix                         = (known after apply)
          + connection_termination             = (known after apply)
          + deregistration_delay               = (known after apply)
          + id                                 = (known after apply)
          + ip_address_type                    = (known after apply)
          + lambda_multi_value_headers_enabled = (known after apply)
          + load_balancer_arns                 = (known after apply)
          + load_balancing_algorithm_type      = (known after apply)
          + load_balancing_anomaly_mitigation  = (known after apply)
          + load_balancing_cross_zone_enabled  = (known after apply)
          + name                               = (known after apply)
          + name_prefix                        = (known after apply)
          + port                               = (known after apply)
          + preserve_client_ip                 = (known after apply)
          + protocol                           = (known after apply)
          + protocol_version                   = (known after apply)
          + proxy_protocol_v2                  = (known after apply)
          + slow_start                         = (known after apply)
          + tags                               = (known after apply)
          + tags_all                           = (known after apply)
          + target_type                        = (known after apply)
          + vpc_id                             = (known after apply)
        } -> (known after apply)

      ~ target_health_state {
          + arn                                = (known after apply)
          + arn_suffix                         = (known after apply)
          + connection_termination             = (known after apply)
          + deregistration_delay               = (known after apply)
          + id                                 = (known after apply)
          + ip_address_type                    = (known after apply)
          + lambda_multi_value_headers_enabled = (known after apply)
          + load_balancer_arns                 = (known after apply)
          + load_balancing_algorithm_type      = (known after apply)
          + load_balancing_anomaly_mitigation  = (known after apply)
          + load_balancing_cross_zone_enabled  = (known after apply)
          + name                               = (known after apply)
          + name_prefix                        = (known after apply)
          + port                               = (known after apply)
          + preserve_client_ip                 = (known after apply)
          + protocol                           = (known after apply)
          + protocol_version                   = (known after apply)
          + proxy_protocol_v2                  = (known after apply)
          + slow_start                         = (known after apply)
          + tags                               = (known after apply)
          + tags_all                           = (known after apply)
          + target_type                        = (known after apply)
          + vpc_id                             = (known after apply)
        } -> (known after apply)
    }

  # module.web.module.ecs_service.module.fargate.aws_ecs_service.main[0] will be updated in-place
  ~ resource "aws_ecs_service" "main" {
      + force_delete                       = false
        id                                 = "arn:aws:ecs:us-east-1:669097061340:service/efiler-api-demo-web/efiler-api-demo-web"
        name                               = "efiler-api-demo-web"
        tags                               = {}
      ~ task_definition                    = "arn:aws:ecs:us-east-1:669097061340:task-definition/efiler-api-demo-web:18" -> (known after apply)
        # (16 unchanged attributes hidden)

      ~ load_balancer {
          + availability_zone_rebalancing      = (known after apply)
          + cluster                            = (known after apply)
          + deployment_maximum_percent         = (known after apply)
          + deployment_minimum_healthy_percent = (known after apply)
          + desired_count                      = (known after apply)
          + enable_ecs_managed_tags            = (known after apply)
          + enable_execute_command             = (known after apply)
          + force_delete                       = (known after apply)
          + force_new_deployment               = (known after apply)
          + health_check_grace_period_seconds  = (known after apply)
          + iam_role                           = (known after apply)
          + id                                 = (known after apply)
          + launch_type                        = (known after apply)
          + name                               = (known after apply)
          + platform_version                   = (known after apply)
          + propagate_tags                     = (known after apply)
          + scheduling_strategy                = (known after apply)
          + tags                               = (known after apply)
          + tags_all                           = (known after apply)
          + task_definition                    = (known after apply)
          + triggers                           = (known after apply)
          + wait_for_steady_state              = (known after apply)
        } -> (known after apply)

        # (3 unchanged blocks hidden)
    }

  # module.web.module.ecs_service.module.fargate.module.task.aws_ecs_task_definition.main[0] must be replaced
+/- resource "aws_ecs_task_definition" "main" {
      ~ arn                      = "arn:aws:ecs:us-east-1:669097061340:task-definition/efiler-api-demo-web:18" -> (known after apply)
      ~ arn_without_revision     = "arn:aws:ecs:us-east-1:669097061340:task-definition/efiler-api-demo-web" -> (known after apply)
      ~ container_definitions    = jsonencode(
          ~ [
              ~ {
                  - mountPoints       = []
                    name              = "efiler-api-demo-web"
                  ~ portMappings      = [
                      ~ {
                          ~ containerPort = 4567 -> 80
                          - hostPort      = 4567
                          - protocol      = "tcp"
                        },
                    ]
                  + secrets           = [
                      + {
                          + name      = "SECRET_KEY_BASE"
                          + valueFrom = "arn:aws:secretsmanager:us-east-1:669097061340:secret:rails_secret_key_base-h1ygaE:key::"
                        },
                    ]
                  - systemControls    = []
                  - volumesFrom       = []
                    # (8 unchanged attributes hidden)
                },
              ~ {
                  - mountPoints      = []
                    name             = "otel-collector"
                  - portMappings     = []
                  - systemControls   = []
                  - volumesFrom      = []
                    # (8 unchanged attributes hidden)
                },
            ] # forces replacement
        )
      ~ id                       = "efiler-api-demo-web" -> (known after apply)
      ~ revision                 = 18 -> (known after apply)
      - tags                     = {} -> null
      ~ tags_all                 = {} -> (known after apply)
        # (10 unchanged attributes hidden)
    }

Plan: 2 to add, 2 to change, 2 to destroy.
```