### PR TITLE
Add AWS lambda function call for PYA datadog logs

### DIFF
--- a/tofu/modules/pya/data.tf
+++ b/tofu/modules/pya/data.tf
@@ -1,0 +1,9 @@
+# Find the lambda function for the Datadog forwarder so that we can use it as a
+# destination for CloudWatch log subscriptions.
+data "aws_lambda_functions" "all" {}
+
+data "aws_lambda_function" "datadog" {
+  for_each = length(local.datadog_lambda) > 0 ? toset(["this"]) : toset([])
+
+  function_name = local.datadog_lambda[0]
+}

--- a/tofu/modules/pya/local.tf
+++ b/tofu/modules/pya/local.tf
@@ -1,0 +1,6 @@
+locals {
+  datadog_lambda = [
+    for lambda in data.aws_lambda_functions.all.function_names :
+    lambda if length(regexall("^DatadogIntegration-ForwarderStack-", lambda)) > 0
+  ]
+}

--- a/tofu/modules/pya/main.tf
+++ b/tofu/modules/pya/main.tf
@@ -275,3 +275,12 @@ module "bastion" {
   private_subnet_ids = module.vpc.private_subnets
   vpc_id             = module.vpc.vpc_id
 }
+
+resource "aws_cloudwatch_log_subscription_filter" "datadog" {
+  for_each = length(local.datadog_lambda) > 0 ? toset(["web", "workers"]) : toset([])
+
+  name            = "datadog"
+  log_group_name  = "/aws/ecs/pya/${var.environment}/${each.key}"
+  filter_pattern  = ""
+  destination_arn = data.aws_lambda_function.datadog["this"].arn
+}


### PR DESCRIPTION
# **Tofu plan for staging**

OpenTofu used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  + create

OpenTofu will perform the following actions:

  # module.pya.aws_cloudwatch_log_subscription_filter.datadog["web"] will be created
  + resource "aws_cloudwatch_log_subscription_filter" "datadog" {
      + destination_arn = "arn:aws:lambda:us-east-1:300423309117:function:DatadogIntegration-ForwarderStack-36RXNP-Forwarder-4HA5ghnV668a"
      + distribution    = "ByLogStream"
      + id              = (known after apply)
      + log_group_name  = "/aws/ecs/pya/staging/web"
      + name            = "datadog"
      + role_arn        = (known after apply)
    }

  # module.pya.aws_cloudwatch_log_subscription_filter.datadog["workers"] will be created
  + resource "aws_cloudwatch_log_subscription_filter" "datadog" {
      + destination_arn = "arn:aws:lambda:us-east-1:300423309117:function:DatadogIntegration-ForwarderStack-36RXNP-Forwarder-4HA5ghnV668a"
      + distribution    = "ByLogStream"
      + id              = (known after apply)
      + log_group_name  = "/aws/ecs/pya/staging/workers"
      + name            = "datadog"
      + role_arn        = (known after apply)
    }

Plan: 2 to add, 0 to change, 0 to destroy.

# **Tofu plan for prod** 

OpenTofu used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  + create
  ~ update in-place

OpenTofu will perform the following actions:

  # module.pya.aws_cloudwatch_log_subscription_filter.datadog["web"] will be created
  + resource "aws_cloudwatch_log_subscription_filter" "datadog" {
      + destination_arn = "arn:aws:lambda:us-east-1:828007041297:function:DatadogIntegration-ForwarderStack-7CG5ZY-Forwarder-YMNtqzUbxhn8"
      + distribution    = "ByLogStream"
      + id              = (known after apply)
      + log_group_name  = "/aws/ecs/pya/production/web"
      + name            = "datadog"
      + role_arn        = (known after apply)
    }

  # module.pya.aws_cloudwatch_log_subscription_filter.datadog["workers"] will be created
  + resource "aws_cloudwatch_log_subscription_filter" "datadog" {
      + destination_arn = "arn:aws:lambda:us-east-1:828007041297:function:DatadogIntegration-ForwarderStack-7CG5ZY-Forwarder-YMNtqzUbxhn8"
      + distribution    = "ByLogStream"
      + id              = (known after apply)
      + log_group_name  = "/aws/ecs/pya/production/workers"
      + name            = "datadog"
      + role_arn        = (known after apply)
    }

  # module.pya.module.logging.module.s3.aws_s3_bucket_server_side_encryption_configuration.main will be updated in-place
  ~ resource "aws_s3_bucket_server_side_encryption_configuration" "main" {
        id     = "pya-production-logs"
        # (1 unchanged attribute hidden)

      - rule {
          - bucket_key_enabled = false -> null

          - apply_server_side_encryption_by_default {
              - sse_algorithm = "AES256" -> null
            }
        }
      + rule {
          + bucket_key_enabled = true

          + apply_server_side_encryption_by_default {
              + sse_algorithm = "AES256"
            }
        }
    }

Plan: 2 to add, 1 to change, 0 to destroy.