### PR TITLE
EFiler API: Switch container port from 80 to 8080

### DIFF
--- a/tofu/config/demo.efilerapi.org/main.tf
+++ b/tofu/config/demo.efilerapi.org/main.tf
@@ -57,7 +57,7 @@ module "web" {
   private_subnets = module.vpc.private_subnets
   public_subnets  = module.vpc.public_subnets
   logging_key_id  = module.logging.kms_key_arn
-  container_port  = 80
+  container_port  = 8080
   create_endpoint = true
   create_repository   = true
   create_version_parameter = true


### PR DESCRIPTION
```

OpenTofu used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  ~ update in-place
-/+ destroy and then create replacement
+/- create replacement and then destroy

OpenTofu will perform the following actions:

  # module.web.module.alb["this"].aws_lb_listener.this["https"] will be updated in-place
  ~ resource "aws_lb_listener" "this" {
        id                                   = "arn:aws:elasticloadbalancing:us-east-1:669097061340:listener/app/efiler-api-demo-web/b6d5632514aa7002/b72241b73909911b"
        tags                                 = {
            "terraform-aws-modules" = "alb"
        }
        # (8 unchanged attributes hidden)

      ~ default_action {
          ~ target_group_arn = "arn:aws:elasticloadbalancing:us-east-1:669097061340:targetgroup/efiler-api-demo-web-80/a844cd67d95155ab" -> (known after apply)
            # (2 unchanged attributes hidden)
        }

        # (1 unchanged block hidden)
    }

  # module.web.module.alb["this"].aws_lb_target_group.this["endpoint"] must be replaced
+/- resource "aws_lb_target_group" "this" {
      ~ arn                                = "arn:aws:elasticloadbalancing:us-east-1:669097061340:targetgroup/efiler-api-demo-web-80/a844cd67d95155ab" -> (known after apply)
      ~ arn_suffix                         = "targetgroup/efiler-api-demo-web-80/a844cd67d95155ab" -> (known after apply)
      + connection_termination             = (known after apply)
      ~ id                                 = "arn:aws:elasticloadbalancing:us-east-1:669097061340:targetgroup/efiler-api-demo-web-80/a844cd67d95155ab" -> (known after apply)
      ~ ip_address_type                    = "ipv4" -> (known after apply)
      ~ load_balancer_arns                 = [
          - "arn:aws:elasticloadbalancing:us-east-1:669097061340:loadbalancer/app/efiler-api-demo-web/b6d5632514aa7002",
        ] -> (known after apply)
      ~ load_balancing_algorithm_type      = "round_robin" -> (known after apply)
      ~ load_balancing_anomaly_mitigation  = "off" -> (known after apply)
      ~ load_balancing_cross_zone_enabled  = "use_load_balancer_configuration" -> (known after apply)
      ~ name                               = "efiler-api-demo-web-80" -> "efiler-api-demo-web-8080" # forces replacement
      + name_prefix                        = (known after apply)
      ~ port                               = 80 -> 8080 # forces replacement
      + preserve_client_ip                 = (known after apply)
      ~ protocol_version                   = "HTTP1" -> (known after apply)
        tags                               = {
            "terraform-aws-modules" = "alb"
        }
        # (8 unchanged attributes hidden)

      ~ health_check {
          ~ matcher             = "200" -> (known after apply)
          ~ timeout             = 5 -> (known after apply)
            # (7 unchanged attributes hidden)
        }

      ~ stickiness {
          + arn                                = (known after apply)
          + arn_suffix                         = (known after apply)
          + connection_termination             = (known after apply)
          + deregistration_delay               = (known after apply)
          + id                                 = (known after apply)
          + ip_address_type                    = (known after apply)
          + lambda_multi_value_headers_enabled = (known after apply)
          + load_balancer_arns                 = (known after apply)
          + load_balancing_algorithm_type      = (known after apply)
          + load_balancing_anomaly_mitigation  = (known after apply)
          + load_balancing_cross_zone_enabled  = (known after apply)
          + name                               = (known after apply)
          + name_prefix                        = (known after apply)
          + port                               = (known after apply)
          + preserve_client_ip                 = (known after apply)
          + protocol                           = (known after apply)
          + protocol_version                   = (known after apply)
          + proxy_protocol_v2                  = (known after apply)
          + slow_start                         = (known after apply)
          + tags                               = (known after apply)
          + tags_all                           = (known after apply)
          + target_type                        = (known after apply)
          + vpc_id                             = (known after apply)
        } -> (known after apply)

      ~ target_failover {
          + arn                                = (known after apply)
          + arn_suffix                         = (known after apply)
          + connection_termination             = (known after apply)
          + deregistration_delay               = (known after apply)
          + id                                 = (known after apply)
          + ip_address_type                    = (known after apply)
          + lambda_multi_value_headers_enabled = (known after apply)
          + load_balancer_arns                 = (known after apply)
          + load_balancing_algorithm_type      = (known after apply)
          + load_balancing_anomaly_mitigation  = (known after apply)
          + load_balancing_cross_zone_enabled  = (known after apply)
          + name                               = (known after apply)
          + name_prefix                        = (known after apply)
          + port                               = (known after apply)
          + preserve_client_ip                 = (known after apply)
          + protocol                           = (known after apply)
          + protocol_version                   = (known after apply)
          + proxy_protocol_v2                  = (known after apply)
          + slow_start                         = (known after apply)
          + tags                               = (known after apply)
          + tags_all                           = (known after apply)
          + target_type                        = (known after apply)
          + vpc_id                             = (known after apply)
        } -> (known after apply)

      ~ target_group_health {
          + arn                                = (known after apply)
          + arn_suffix                         = (known after apply)
          + connection_termination             = (known after apply)
          + deregistration_delay               = (known after apply)
          + id                                 = (known after apply)
          + ip_address_type                    = (known after apply)
          + lambda_multi_value_headers_enabled = (known after apply)
          + load_balancer_arns                 = (known after apply)
          + load_balancing_algorithm_type      = (known after apply)
          + load_balancing_anomaly_mitigation  = (known after apply)
          + load_balancing_cross_zone_enabled  = (known after apply)
          + name                               = (known after apply)
          + name_prefix                        = (known after apply)
          + port                               = (known after apply)
          + preserve_client_ip                 = (known after apply)
          + protocol                           = (known after apply)
          + protocol_version                   = (known after apply)
          + proxy_protocol_v2                  = (known after apply)
          + slow_start                         = (known after apply)
          + tags                               = (known after apply)
          + tags_all                           = (known after apply)
          + target_type                        = (known after apply)
          + vpc_id                             = (known after apply)
        } -> (known after apply)

      ~ target_health_state {
          + arn                                = (known after apply)
          + arn_suffix                         = (known after apply)
          + connection_termination             = (known after apply)
          + deregistration_delay               = (known after apply)
          + id                                 = (known after apply)
          + ip_address_type                    = (known after apply)
          + lambda_multi_value_headers_enabled = (known after apply)
          + load_balancer_arns                 = (known after apply)
          + load_balancing_algorithm_type      = (known after apply)
          + load_balancing_anomaly_mitigation  = (known after apply)
          + load_balancing_cross_zone_enabled  = (known after apply)
          + name                               = (known after apply)
          + name_prefix                        = (known after apply)
          + port                               = (known after apply)
          + preserve_client_ip                 = (known after apply)
          + protocol                           = (known after apply)
          + protocol_version                   = (known after apply)
          + proxy_protocol_v2                  = (known after apply)
          + slow_start                         = (known after apply)
          + tags                               = (known after apply)
          + tags_all                           = (known after apply)
          + target_type                        = (known after apply)
          + vpc_id                             = (known after apply)
        } -> (known after apply)
    }

  # module.web.module.task_security_group.aws_security_group_rule.ingress_with_source_security_group_id[0] must be replaced
-/+ resource "aws_security_group_rule" "ingress_with_source_security_group_id" {
      ~ from_port                = 80 -> 8080 # forces replacement
      ~ id                       = "sgrule-3406898088" -> (known after apply)
      ~ security_group_rule_id   = "sgr-0d0f33cd2d3a7c9d5" -> (known after apply)
      ~ to_port                  = 80 -> 8080 # forces replacement
        # (7 unchanged attributes hidden)
    }

  # module.web.module.ecs_service.module.fargate.aws_ecs_service.main[0] will be updated in-place
  ~ resource "aws_ecs_service" "main" {
        id                                 = "arn:aws:ecs:us-east-1:669097061340:service/efiler-api-demo-web/efiler-api-demo-web"
        name                               = "efiler-api-demo-web"
        tags                               = {}
      ~ task_definition                    = "arn:aws:ecs:us-east-1:669097061340:task-definition/efiler-api-demo-web:25" -> (known after apply)
        # (17 unchanged attributes hidden)

      ~ load_balancer {
          + availability_zone_rebalancing      = (known after apply)
          + cluster                            = (known after apply)
          + deployment_maximum_percent         = (known after apply)
          + deployment_minimum_healthy_percent = (known after apply)
          + desired_count                      = (known after apply)
          + enable_ecs_managed_tags            = (known after apply)
          + enable_execute_command             = (known after apply)
          + force_delete                       = (known after apply)
          + force_new_deployment               = (known after apply)
          + health_check_grace_period_seconds  = (known after apply)
          + iam_role                           = (known after apply)
          + id                                 = (known after apply)
          + launch_type                        = (known after apply)
          + name                               = (known after apply)
          + platform_version                   = (known after apply)
          + propagate_tags                     = (known after apply)
          + scheduling_strategy                = (known after apply)
          + tags                               = (known after apply)
          + tags_all                           = (known after apply)
          + task_definition                    = (known after apply)
          + triggers                           = (known after apply)
          + wait_for_steady_state              = (known after apply)
        } -> (known after apply)

        # (3 unchanged blocks hidden)
    }

  # module.web.module.ecs_service.module.fargate.module.task.aws_ecs_task_definition.main[0] must be replaced
+/- resource "aws_ecs_task_definition" "main" {
      ~ arn                      = "arn:aws:ecs:us-east-1:669097061340:task-definition/efiler-api-demo-web:25" -> (known after apply)
      ~ arn_without_revision     = "arn:aws:ecs:us-east-1:669097061340:task-definition/efiler-api-demo-web" -> (known after apply)
      ~ container_definitions    = jsonencode(
          ~ [
              ~ {
                  - mountPoints       = []
                    name              = "efiler-api-demo-web"
                  ~ portMappings      = [
                      ~ {
                          ~ containerPort = 80 -> 8080
                          - hostPort      = 80
                          - protocol      = "tcp"
                        },
                    ]
                  - systemControls    = []
                  - volumesFrom       = []
                    # (9 unchanged attributes hidden)
                },
              ~ {
                  - mountPoints      = []
                    name             = "otel-collector"
                  - portMappings     = []
                  - systemControls   = []
                  - volumesFrom      = []
                    # (8 unchanged attributes hidden)
                },
            ] # forces replacement
        )
      ~ id                       = "efiler-api-demo-web" -> (known after apply)
      ~ revision                 = 25 -> (known after apply)
      - tags                     = {} -> null
      ~ tags_all                 = {} -> (known after apply)
        # (10 unchanged attributes hidden)
    }

Plan: 3 to add, 2 to change, 3 to destroy.
```