### PR TITLE
TBE-200 Add efiler-api production infrastructure

### DIFF
--- a/tofu/config/efiler-api.fileyourstatetaxes.org/main.tf
+++ b/tofu/config/efiler-api.fileyourstatetaxes.org/main.tf
@@ -20,6 +20,6 @@ module "efiler_api" {
   environment         = "production"
   domain              = "efiler-api.fileyourstatetaxes.org"
   cidr                = "10.0.60.0/22"
-  private_subnets     = ["10.0.62.0/26", "10.0.62.64/26", "10.0.62.128/2"]
+  private_subnets     = ["10.0.62.0/26", "10.0.62.64/26", "10.0.62.128/26"]
   public_subnets      = ["10.0.60.0/26", "10.0.60.64/26", "10.0.60.128/26"]
 }

--- a/tofu/config/efiler-api.fileyourstatetaxes.org/main.tf
+++ b/tofu/config/efiler-api.fileyourstatetaxes.org/main.tf
@@ -1,11 +1,11 @@
-# terraform {
-#   backend "s3" {
-#     bucket         = "efiler-api-production-tfstate"
-#     key            = "production.efiler-api.fileyourstatetaxes.org"
-#     region         = "us-east-1"
-#     dynamodb_table = "production.tfstate"
-#   }
-# }
+terraform {
+  backend "s3" {
+    bucket         = "efiler-api-production-tfstate"
+    key            = "production.efiler-api.fileyourstatetaxes.org"
+    region         = "us-east-1"
+    dynamodb_table = "production.tfstate"
+  }
+}
 
 module "backend" {
   source = "github.com/codeforamerica/tofu-modules-aws-backend?ref=1.1.1"
@@ -14,12 +14,12 @@ module "backend" {
   environment = "production"
 }
 
-# module "efiler_api" {
-#   source = "../../modules/efiler_api"
-#
-#   environment         = "production"
-#   domain              = "production.efiler-api.fileyourstatetaxes.org"
-#   cidr                = "10.0.60.0/22"
-#   private_subnets     = ["10.0.62.0/26", "10.0.62.64/26", "10.0.62.128/2"]
-#   public_subnets      = ["10.0.60.0/26", "10.0.60.64/26", "10.0.60.128/26"]
-# }
+module "efiler_api" {
+  source = "../../modules/efiler_api"
+
+  environment         = "production"
+  domain              = "production.efiler-api.fileyourstatetaxes.org"
+  cidr                = "10.0.60.0/22"
+  private_subnets     = ["10.0.62.0/26", "10.0.62.64/26", "10.0.62.128/2"]
+  public_subnets      = ["10.0.60.0/26", "10.0.60.64/26", "10.0.60.128/26"]
+}

--- a/tofu/config/efiler-api.fileyourstatetaxes.org/main.tf
+++ b/tofu/config/efiler-api.fileyourstatetaxes.org/main.tf
@@ -18,7 +18,7 @@ module "efiler_api" {
   source = "../../modules/efiler_api"
 
   environment         = "production"
-  domain              = "production.efiler-api.fileyourstatetaxes.org"
+  domain              = "efiler-api.fileyourstatetaxes.org"
   cidr                = "10.0.60.0/22"
   private_subnets     = ["10.0.62.0/26", "10.0.62.64/26", "10.0.62.128/2"]
   public_subnets      = ["10.0.60.0/26", "10.0.60.64/26", "10.0.60.128/26"]

--- a/tofu/config/efiler-api.fileyourstatetaxes.org/main.tf
+++ b/tofu/config/efiler-api.fileyourstatetaxes.org/main.tf
@@ -1,7 +1,7 @@
 terraform {
   backend "s3" {
     bucket         = "efiler-api-production-tfstate"
-    key            = "production.efiler-api.fileyourstatetaxes.org"
+    key            = "efiler-api.fileyourstatetaxes.org"
     region         = "us-east-1"
     dynamodb_table = "production.tfstate"
   }


### PR DESCRIPTION
steps we took:
- we uncommented just the terraform block and ran `tofu apply` and then `tofu init -migrate-state`
  - in reality it was a little more complicated than that because we had tried to run apply via the GH action which we learned was a no-no
- we went through the steps to set up a hosted zone in fileyourstatetaxes.org since we don't have a dedicated domain
- we uncommented the efiler_api module and ran tofu plan via the GH action on the branch. [output here](https://github.com/codeforamerica/tax-benefits-backend/actions/runs/17503767734/job/49722679446)