### PR TITLE
efiler-api: add secret keys to efiler_api module

### DIFF
--- a/tofu/modules/efiler_api/main.tf
+++ b/tofu/modules/efiler_api/main.tf
@@ -18,12 +18,34 @@ module "vpc" {
 }
 
 module "secrets" {
-  source = "github.com/codeforamerica/tofu-modules-aws-secrets?ref=1.0.0"
+  source = "github.com/codeforamerica/tofu-modules-aws-secrets?ref=2.0.0"
 
   project     = "efiler-api"
   environment = var.environment
 
   secrets = {
+    "efiler-api-client-credentials/efiler_api_test_client" = {
+      description = "credentials for api_test_client"
+      add_suffix = false
+      start_value = jsonencode({
+        app_sys_id = ""
+        etin = ""
+        cert_base64 = ""
+        mef_env = ""
+        efiler_api_public_key = ""
+      })
+    },
+    "efiler-api-client-credentials/efiler_api_test_client_two" = {
+      description = "credentials for api_test_client_two"
+      add_suffix = false
+      start_value = jsonencode({
+        app_sys_id = ""
+        etin = ""
+        cert_base64 = ""
+        mef_env = ""
+        efiler_api_public_key = ""
+      })
+    }
   }
 }
 


### PR DESCRIPTION
now that we can prevent the tofu secrets module from adding a random suffix to secret names, we're adding the secret keys/structure back to the secrets module so that we can automatically generate the role and the secret keys

[plan output](https://github.com/codeforamerica/tax-benefits-backend/actions/runs/17562215553/job/49881062704)