### PR TITLE
TBE-200 Add providers.tf to demo.efiler-api.fileyourstatetaxes.org

### DIFF
--- a/tofu/config/demo.efiler-api.fileyourstatetaxes.org/providers.tf
+++ b/tofu/config/demo.efiler-api.fileyourstatetaxes.org/providers.tf
@@ -1,0 +1,10 @@
+provider "aws" {
+  region = "us-east-1"
+
+  default_tags {
+    tags = {
+      project     = "efiler-api"
+      environment = "demo"
+    }
+  }
+}


### PR DESCRIPTION
We forgot to add this file. The resources aren't tagged correctly, and the CLI can't find the bastion as a result. The plan results can be found here: https://github.com/codeforamerica/tax-benefits-backend/actions/runs/17596354110