### PR TITLE
reenable worker module, re-add worker to key policy and correct container command

### DIFF
--- a/tofu/modules/gyraffe/main.tf
+++ b/tofu/modules/gyraffe/main.tf
@@ -108,50 +108,50 @@ module "web" {
   }
 }
 
-# module "workers" {
-#   source = "github.com/codeforamerica/tofu-modules-aws-fargate-service?ref=1.6.1"
-#
-#   project       = "gyraffe"
-#   project_short = "gyraffe"
-#   environment   = var.environment
-#   service       = "worker"
-#   service_short = "worker"
-#
-#   vpc_id          = module.vpc.vpc_id
-#   private_subnets = module.vpc.private_subnets
-#   public_subnets  = module.vpc.public_subnets
-#   logging_key_id  = module.logging.kms_key_arn
-#   container_port  = 8080
-#   version_parameter = module.web.version_parameter
-#   image_url = module.web.repository_url
-#   create_endpoint = false
-#   create_repository = false
-#   enable_execute_command = true
-#
-#   execution_policies = [aws_iam_policy.ecs_s3_access.arn]
-#   task_policies = [aws_iam_policy.ecs_s3_access.arn]
-#
-#   environment_variables = {
-#     RACK_ENV = var.environment
-#     DATABASE_HOST = module.database.cluster_endpoint
-#     REVIEW_APP = var.review_app
-#   }
-#   environment_secrets = {
-#     DATABASE_PASSWORD           = "${module.database.secret_arn}:password"
-#     DATABASE_USER               = "${module.database.secret_arn}:username"
-#     SECRET_KEY_BASE             = module.secrets.secrets["rails_secret_key_base"].secret_arn
-#     TWILIO_ACCOUNT_SID          = module.secrets.secrets["twilio_account_sid"].secret_arn
-#     TWILIO_AUTH_TOKEN           = module.secrets.secrets["twilio_auth_token"].secret_arn
-#     TWILIO_MESSAGING_SERVICE    = module.secrets.secrets["twilio_messaging_service_sid"].secret_arn
-#     MAILGUN_API_KEY             = module.secrets.secrets["mailgun_api_key"].secret_arn
-#     MAILGUN_DOMAIN              = module.secrets.secrets["mailgun_domain"].secret_arn
-#     MAILGUN_BASIC_AUTH_NAME     = module.secrets.secrets["mailgun_basic_auth_name"].secret_arn
-#     MAILGUN_BASIC_AUTH_PASSWORD = module.secrets.secrets["mailgun_basic_auth_password"].secret_arn
-#   }
-#
-#   container_command = ["bundle", "exec", "rake", "jobs:work"]
-#   repository_arn = module.web.repository_arn
-# }
+module "workers" {
+  source = "github.com/codeforamerica/tofu-modules-aws-fargate-service?ref=1.6.1"
+
+  project       = "gyraffe"
+  project_short = "gyraffe"
+  environment   = var.environment
+  service       = "worker"
+  service_short = "worker"
+
+  vpc_id          = module.vpc.vpc_id
+  private_subnets = module.vpc.private_subnets
+  public_subnets  = module.vpc.public_subnets
+  logging_key_id  = module.logging.kms_key_arn
+  container_port  = 8080
+  version_parameter = module.web.version_parameter
+  image_url = module.web.repository_url
+  create_endpoint = false
+  create_repository = false
+  enable_execute_command = true
+
+  execution_policies = [aws_iam_policy.ecs_s3_access.arn]
+  task_policies = [aws_iam_policy.ecs_s3_access.arn]
+
+  environment_variables = {
+    RACK_ENV = var.environment
+    DATABASE_HOST = module.database.cluster_endpoint
+    REVIEW_APP = var.review_app
+  }
+  environment_secrets = {
+    DATABASE_PASSWORD           = "${module.database.secret_arn}:password"
+    DATABASE_USER               = "${module.database.secret_arn}:username"
+    SECRET_KEY_BASE             = module.secrets.secrets["rails_secret_key_base"].secret_arn
+    TWILIO_ACCOUNT_SID          = module.secrets.secrets["twilio_account_sid"].secret_arn
+    TWILIO_AUTH_TOKEN           = module.secrets.secrets["twilio_auth_token"].secret_arn
+    TWILIO_MESSAGING_SERVICE    = module.secrets.secrets["twilio_messaging_service_sid"].secret_arn
+    MAILGUN_API_KEY             = module.secrets.secrets["mailgun_api_key"].secret_arn
+    MAILGUN_DOMAIN              = module.secrets.secrets["mailgun_domain"].secret_arn
+    MAILGUN_BASIC_AUTH_NAME     = module.secrets.secrets["mailgun_basic_auth_name"].secret_arn
+    MAILGUN_BASIC_AUTH_PASSWORD = module.secrets.secrets["mailgun_basic_auth_password"].secret_arn
+  }
+
+  container_command = ["bin/jobs"]
+  repository_arn = module.web.repository_arn
+}
 
 module "database" {
   source = "github.com/codeforamerica/tofu-modules-aws-serverless-database?ref=1.3.1"

--- a/tofu/modules/gyraffe/templates/key-policy.json.tftpl
+++ b/tofu/modules/gyraffe/templates/key-policy.json.tftpl
@@ -39,7 +39,8 @@
       "Effect": "Allow",
       "Principal": {
         "AWS": [
-          "arn:aws:iam::${account_id}:role/gyraffe-${environment}-web-task"
+          "arn:aws:iam::${account_id}:role/gyraffe-${environment}-web-task",
+          "arn:aws:iam::${account_id}:role/gyraffe-${environment}-worker-task"
         ]
       },
       "Action": [


### PR DESCRIPTION
```

OpenTofu used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  + create
  ~ update in-place

OpenTofu will perform the following actions:

  # module.gyraffe.aws_kms_key.submission_bundles will be updated in-place
  ~ resource "aws_kms_key" "submission_bundles" {
        id                                 = "5f45585e-6b7c-49ef-99c6-62e4cfe4a1a2"
      ~ policy                             = jsonencode(
          ~ {
              ~ Statement = [
                    # (1 unchanged element hidden)
                    {
                        Action    = [
                            "kms:Decrypt",
                            "kms:Encrypt",
                            "kms:GenerateDataKey",
                            "kms:ReEncrypt*",
                        ]
                        Condition = {
                            StringLike = {
                                "kms:CallerAccount"                = "564912844385"
                                "kms:EncryptionContext:aws:s3:arn" = [
                                    "submission-bundles-staging",
                                    "submission-bundles-staging/*",
                                ]
                            }
                        }
                        Effect    = "Allow"
                        Principal = {
                            AWS = "*"
                        }
                        Resource  = "*"
                        Sid       = "Allow S3 to encrypt and decrypt objects"
                    },
                  ~ {
                      ~ Principal = {
                          ~ AWS = [
                                "arn:aws:iam::564912844385:role/gyraffe-staging-web-task",
                              + "arn:aws:iam::564912844385:role/gyraffe-staging-worker-task",
                            ]
                        }
                        # (4 unchanged attributes hidden)
                    },
                ]
                # (2 unchanged attributes hidden)
            }
        )
        tags                               = {}
        # (12 unchanged attributes hidden)
    }

  # module.gyraffe.module.workers.aws_cloudwatch_log_group.service will be created
  + resource "aws_cloudwatch_log_group" "service" {
      + arn               = (known after apply)
      + id                = (known after apply)
      + kms_key_id        = "arn:aws:kms:us-east-1:564912844385:key/a6a1a418-4662-426c-88cd-177e95809e1f"
      + log_group_class   = (known after apply)
      + name              = "/aws/ecs/gyraffe/staging/worker"
      + name_prefix       = (known after apply)
      + retention_in_days = 30
      + skip_destroy      = false
      + tags_all          = {
          + "environment" = "staging"
          + "project"     = "gyraffe"
        }
    }

  # module.gyraffe.module.workers.aws_iam_policy.execution will be created
  + resource "aws_iam_policy" "execution" {
      + arn              = (known after apply)
      + attachment_count = (known after apply)
      + description      = "worker task execution policy for gyraffe staging."
      + id               = (known after apply)
      + name             = "gyraffe-staging-worker-execution"
      + name_prefix      = (known after apply)
      + path             = "/"
      + policy           = jsonencode(
            {
              + Statement = [
                  + {
                      + Action   = [
                          + "ecr:GetAuthorizationToken",
                        ]
                      + Effect   = "Allow"
                      + Resource = "*"
                      + Sid      = "ECRAuthToken"
                    },
                  + {
                      + Action   = [
                          + "ecr:BatchCheckLayerAvailability",
                          + "ecr:GetDownloadUrlForLayer",
                          + "ecr:BatchGetImage",
                        ]
                      + Effect   = "Allow"
                      + Resource = "arn:aws:ecr:us-east-1:564912844385:repository/gyraffe-staging-web"
                      + Sid      = "ECRRepositoryAccess"
                    },
                  + {
                      + Action    = [
                          + "logs:CreateLogStream",
                          + "logs:PutLogEvents",
                        ]
                      + Condition = {
                          + StringEquals = {
                              + "aws:RequestTag/environment" = "staging"
                              + "aws:RequestTag/project"     = "gyraffe"
                            }
                        }
                      + Effect    = "Allow"
                      + Resource  = "*"
                      + Sid       = "LogWrite"
                    },
                ]
              + Version   = "2012-10-17"
            }
        )
      + policy_id        = (known after apply)
      + tags_all         = {
          + "environment" = "staging"
          + "project"     = "gyraffe"
        }
    }

  # module.gyraffe.module.workers.aws_iam_policy.secrets will be created
  + resource "aws_iam_policy" "secrets" {
      + arn              = (known after apply)
      + attachment_count = (known after apply)
      + description      = "Allow acceess to worker secrets for gyraffe staging."
      + id               = (known after apply)
      + name             = (known after apply)
      + name_prefix      = "gyraffe-staging-worker-secrets-access-"
      + path             = "/"
      + policy           = (known after apply)
      + policy_id        = (known after apply)
      + tags_all         = {
          + "environment" = "staging"
          + "project"     = "gyraffe"
        }
    }

  # module.gyraffe.module.workers.aws_iam_role.execution will be created
  + resource "aws_iam_role" "execution" {
      + arn                   = (known after apply)
      + assume_role_policy    = jsonencode(
            {
              + Statement = [
                  + {
                      + Action    = "sts:AssumeRole"
                      + Effect    = "Allow"
                      + Principal = {
                          + Service = "ecs-tasks.amazonaws.com"
                        }
                    },
                ]
              + Version   = "2012-10-17"
            }
        )
      + create_date           = (known after apply)
      + description           = "worker task execution role for gyraffe staging."
      + force_detach_policies = false
      + id                    = (known after apply)
      + managed_policy_arns   = (known after apply)
      + max_session_duration  = 3600
      + name                  = "gyraffe-staging-worker-execution"
      + name_prefix           = (known after apply)
      + path                  = "/"
      + tags_all              = {
          + "environment" = "staging"
          + "project"     = "gyraffe"
        }
      + unique_id             = (known after apply)

      + inline_policy (known after apply)
    }

  # module.gyraffe.module.workers.aws_iam_role.task will be created
  + resource "aws_iam_role" "task" {
      + arn                   = (known after apply)
      + assume_role_policy    = jsonencode(
            {
              + Statement = [
                  + {
                      + Action    = "sts:AssumeRole"
                      + Effect    = "Allow"
                      + Principal = {
                          + Service = "ecs-tasks.amazonaws.com"
                        }
                    },
                ]
              + Version   = "2012-10-17"
            }
        )
      + create_date           = (known after apply)
      + description           = "worker task role for gyraffe staging."
      + force_detach_policies = false
      + id                    = (known after apply)
      + managed_policy_arns   = (known after apply)
      + max_session_duration  = 3600
      + name                  = "gyraffe-staging-worker-task"
      + name_prefix           = (known after apply)
      + path                  = "/"
      + tags_all              = {
          + "environment" = "staging"
          + "project"     = "gyraffe"
        }
      + unique_id             = (known after apply)

      + inline_policy (known after apply)
    }

  # module.gyraffe.module.workers.aws_iam_role_policy_attachments_exclusive.execution will be created
  + resource "aws_iam_role_policy_attachments_exclusive" "execution" {
      + policy_arns = [
          + "arn:aws:iam::564912844385:policy/gyraffe-staging-ecs-s3-access",
          + "arn:aws:iam::aws:policy/CloudWatchAgentServerPolicy",
          + "arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy",
          + (known after apply),
        ]
      + role_name   = "gyraffe-staging-worker-execution"
    }

  # module.gyraffe.module.workers.aws_iam_role_policy_attachments_exclusive.task will be created
  + resource "aws_iam_role_policy_attachments_exclusive" "task" {
      + policy_arns = [
          + "arn:aws:iam::564912844385:policy/gyraffe-staging-ecs-s3-access",
          + "arn:aws:iam::aws:policy/AmazonSSMFullAccess",
          + "arn:aws:iam::aws:policy/CloudWatchAgentServerPolicy",
          + "arn:aws:iam::aws:policy/CloudWatchFullAccess",
          + (known after apply),
        ]
      + role_name   = "gyraffe-staging-worker-task"
    }

  # module.gyraffe.module.workers.aws_kms_alias.fargate will be created
  + resource "aws_kms_alias" "fargate" {
      + arn            = (known after apply)
      + id             = (known after apply)
      + name           = "alias/gyraffe/staging/worker"
      + name_prefix    = (known after apply)
      + target_key_arn = (known after apply)
      + target_key_id  = (known after apply)
    }

  # module.gyraffe.module.workers.aws_kms_key.fargate will be created
  + resource "aws_kms_key" "fargate" {
      + arn                                = (known after apply)
      + bypass_policy_lockout_safety_check = false
      + customer_master_key_spec           = "SYMMETRIC_DEFAULT"
      + deletion_window_in_days            = 30
      + description                        = "worker hosting encryption key for gyraffe staging"
      + enable_key_rotation                = true
      + id                                 = (known after apply)
      + is_enabled                         = true
      + key_id                             = (known after apply)
      + key_usage                          = "ENCRYPT_DECRYPT"
      + multi_region                       = (known after apply)
      + policy                             = jsonencode(
            {
              + Id        = "Fargate hosting key policy"
              + Statement = [
                  + {
                      + Action    = "kms:*"
                      + Effect    = "Allow"
                      + Principal = {
                          + AWS = "arn:aws:iam::564912844385:root"
                        }
                      + Resource  = "*"
                      + Sid       = "Enable IAM User Permissions"
                    },
                  + {
                      + Action    = [
                          + "kms:Decrypt",
                          + "kms:Encrypt",
                          + "kms:GenerateDataKey",
                          + "kms:ReEncrypt*",
                        ]
                      + Condition = {
                          + StringEquals = {
                              + "kms:CallerAccount"                 = "564912844385"
                              + "kms:EncryptionContext:aws:ecr:arn" = "arn:aws:ecr:us-east-1:564912844385:repository/gyraffe-staging-worker"
                            }
                        }
                      + Effect    = "Allow"
                      + Principal = {
                          + AWS = "*"
                        }
                      + Resource  = "*"
                      + Sid       = "Allow ECR to encrypt container images"
                    },
                  + {
                      + Action    = [
                          + "kms:GenerateDataKey*",
                        ]
                      + Effect    = "Allow"
                      + Principal = {
                          + AWS = "*"
                        }
                      + Resource  = "*"
                      + Sid       = "Allow Fargate containers to encrypt objects"
                    },
                ]
              + Version   = "2012-10-17"
            }
        )
      + rotation_period_in_days            = (known after apply)
      + tags_all                           = {
          + "environment" = "staging"
          + "project"     = "gyraffe"
        }
    }

  # module.gyraffe.module.workers.module.ecs.aws_ecs_cluster.main will be created
  + resource "aws_ecs_cluster" "main" {
      + arn      = (known after apply)
      + id       = (known after apply)
      + name     = "gyraffe-staging-worker"
      + tags_all = {
          + "environment" = "staging"
          + "project"     = "gyraffe"
        }

      + setting {
          + name  = "containerInsights"
          + value = "enabled"
        }
    }

  # module.gyraffe.module.workers.module.ecs.aws_ecs_cluster_capacity_providers.main[0] will be created
  + resource "aws_ecs_cluster_capacity_providers" "main" {
      + capacity_providers = [
          + "FARGATE",
        ]
      + cluster_name       = "gyraffe-staging-worker"
      + id                 = (known after apply)
    }

  # module.gyraffe.module.workers.module.endpoint_security_group.aws_security_group.this_name_prefix[0] will be created
  + resource "aws_security_group" "this_name_prefix" {
      + arn                    = (known after apply)
      + description            = "Security Group managed by Terraform"
      + egress                 = (known after apply)
      + id                     = (known after apply)
      + ingress                = (known after apply)
      + name                   = (known after apply)
      + name_prefix            = "gyraffe-staging-worker-endpoint-"
      + owner_id               = (known after apply)
      + revoke_rules_on_delete = false
      + tags                   = {
          + "Name" = "gyraffe-staging-worker-endpoint"
        }
      + tags_all               = {
          + "Name"        = "gyraffe-staging-worker-endpoint"
          + "environment" = "staging"
          + "project"     = "gyraffe"
        }
      + vpc_id                 = "vpc-04840afb129303f79"

      + timeouts {
          + create = "10m"
          + delete = "15m"
        }
    }

  # module.gyraffe.module.workers.module.endpoint_security_group.aws_security_group_rule.egress_rules[0] will be created
  + resource "aws_security_group_rule" "egress_rules" {
      + cidr_blocks              = [
          + "10.0.68.0/22",
        ]
      + description              = "All protocols"
      + from_port                = -1
      + id                       = (known after apply)
      + ipv6_cidr_blocks         = []
      + prefix_list_ids          = []
      + protocol                 = "-1"
      + security_group_id        = (known after apply)
      + security_group_rule_id   = (known after apply)
      + self                     = false
      + source_security_group_id = (known after apply)
      + to_port                  = -1
      + type                     = "egress"
    }

  # module.gyraffe.module.workers.module.endpoint_security_group.aws_security_group_rule.ingress_rules[0] will be created
  + resource "aws_security_group_rule" "ingress_rules" {
      + cidr_blocks              = [
          + "10.0.68.0/22",
        ]
      + description              = "HTTP"
      + from_port                = 80
      + id                       = (known after apply)
      + ipv6_cidr_blocks         = []
      + prefix_list_ids          = []
      + protocol                 = "tcp"
      + security_group_id        = (known after apply)
      + security_group_rule_id   = (known after apply)
      + self                     = false
      + source_security_group_id = (known after apply)
      + to_port                  = 80
      + type                     = "ingress"
    }

  # module.gyraffe.module.workers.module.endpoint_security_group.aws_security_group_rule.ingress_rules[1] will be created
  + resource "aws_security_group_rule" "ingress_rules" {
      + cidr_blocks              = [
          + "10.0.68.0/22",
        ]
      + description              = "HTTPS"
      + from_port                = 443
      + id                       = (known after apply)
      + ipv6_cidr_blocks         = []
      + prefix_list_ids          = []
      + protocol                 = "tcp"
      + security_group_id        = (known after apply)
      + security_group_rule_id   = (known after apply)
      + self                     = false
      + source_security_group_id = (known after apply)
      + to_port                  = 443
      + type                     = "ingress"
    }

  # module.gyraffe.module.workers.module.otel_config.aws_ssm_parameter.this[0] will be created
  + resource "aws_ssm_parameter" "this" {
      + arn            = (known after apply)
      + data_type      = (known after apply)
      + description    = "Configuration for the OpenTelemetry collector."
      + has_value_wo   = (known after apply)
      + id             = (known after apply)
      + insecure_value = <<-EOT
            extensions:
              health_check:

            receivers:
              otlp:
                protocols:
                  grpc:
                    endpoint: 0.0.0.0:4317
                  http:
                    endpoint: 0.0.0.0:4318
              awsxray:
                endpoint: 0.0.0.0:2000
                transport: udp
              statsd:
                endpoint: 0.0.0.0:8125
                aggregation_interval: 60s
              awsecscontainermetrics:

            processors:
              batch/traces:
                timeout: 1s
                send_batch_size: 50
              batch/metrics:
                timeout: 60s
              filter:
                metrics:
                  include:
                    match_type: strict
                    metric_names:
                      - ecs.task.memory.reserved
                      - ecs.task.memory.utilized
                      - ecs.task.cpu.reserved
                      - ecs.task.cpu.utilized
                      - ecs.task.network.rate.rx
                      - ecs.task.network.rate.tx
                      - ecs.task.storage.read_bytes
                      - ecs.task.storage.write_bytes
                      - container.duration
              metricstransform:
                transforms:
                  - include: ecs.task.memory.utilized
                    action: update
                    new_name: MemoryUtilized
                  - include: ecs.task.memory.reserved
                    action: update
                    new_name: MemoryReserved
                  - include: ecs.task.cpu.utilized
                    action: update
                    new_name: CpuUtilized
                  - include: ecs.task.cpu.reserved
                    action: update
                    new_name: CpuReserved
                  - include: ecs.task.network.rate.rx
                    action: update
                    new_name: NetworkRxBytes
                  - include: ecs.task.network.rate.tx
                    action: update
                    new_name: NetworkTxBytes
                  - include: ecs.task.storage.read_bytes
                    action: update
                    new_name: StorageReadBytes
                  - include: ecs.task.storage.write_bytes
                    action: update
                    new_name: StorageWriteBytes

              resource:
                attributes:
                  - key: ClusterName
                    from_attribute: aws.ecs.cluster.name
                    action: insert
                  - key: aws.ecs.cluster.name
                    action: delete
                  - key: ServiceName
                    from_attribute: aws.ecs.service.name
                    action: insert
                  - key: aws.ecs.service.name
                    action: delete
                  - key: TaskId
                    from_attribute: aws.ecs.task.id
                    action: insert
                  - key: aws.ecs.task.id
                    action: delete
                  - key: TaskDefinitionFamily
                    from_attribute: aws.ecs.task.family
                    action: insert
                  - key: aws.ecs.task.family
                    action: delete
                  - key: TaskARN
                    from_attribute: aws.ecs.task.arn
                    action: insert
                  - key: aws.ecs.task.arn
                    action: delete
                  - key: DockerName
                    from_attribute: aws.ecs.docker.name
                    action: insert
                  - key: aws.ecs.docker.name
                    action: delete
                  - key: TaskDefinitionRevision
                    from_attribute: aws.ecs.task.version
                    action: insert
                  - key: aws.ecs.task.version
                    action: delete
                  - key: PullStartedAt
                    from_attribute: aws.ecs.task.pull_started_at
                    action: insert
                  - key: aws.ecs.task.pull_started_at
                    action: delete
                  - key: PullStoppedAt
                    from_attribute: aws.ecs.task.pull_stopped_at
                    action: insert
                  - key: aws.ecs.task.pull_stopped_at
                    action: delete
                  - key: AvailabilityZone
                    from_attribute: cloud.zone
                    action: insert
                  - key: cloud.zone
                    action: delete
                  - key: LaunchType
                    from_attribute: aws.ecs.task.launch_type
                    action: insert
                  - key: aws.ecs.task.launch_type
                    action: delete
                  - key: Region
                    from_attribute: cloud.region
                    action: insert
                  - key: cloud.region
                    action: delete
                  - key: AccountId
                    from_attribute: cloud.account.id
                    action: insert
                  - key: cloud.account.id
                    action: delete
                  - key: DockerId
                    from_attribute: container.id
                    action: insert
                  - key: container.id
                    action: delete
                  - key: ContainerName
                    from_attribute: container.name
                    action: insert
                  - key: container.name
                    action: delete
                  - key: Image
                    from_attribute: container.image.name
                    action: insert
                  - key: container.image.name
                    action: delete
                  - key: ImageId
                    from_attribute: aws.ecs.container.image.id
                    action: insert
                  - key: aws.ecs.container.image.id
                    action: delete
                  - key: ExitCode
                    from_attribute: aws.ecs.container.exit_code
                    action: insert
                  - key: aws.ecs.container.exit_code
                    action: delete
                  - key: CreatedAt
                    from_attribute: aws.ecs.container.created_at
                    action: insert
                  - key: aws.ecs.container.created_at
                    action: delete
                  - key: StartedAt
                    from_attribute: aws.ecs.container.started_at
                    action: insert
                  - key: aws.ecs.container.started_at
                    action: delete
                  - key: FinishedAt
                    from_attribute: aws.ecs.container.finished_at
                    action: insert
                  - key: aws.ecs.container.finished_at
                    action: delete
                  - key: ImageTag
                    from_attribute: container.image.tag
                    action: insert
                  - key: container.image.tag
                    action: delete

            exporters:
              awsxray:
              awsemf/application:
                namespace: "gyraffe/worker"
                log_group_name: '/aws/ecs/application/metrics'
              awsemf/performance:
                namespace: ECS/ContainerInsights
                log_group_name: '/aws/ecs/containerinsights/{ClusterName}/performance'
                log_stream_name: '{TaskId}'
                resource_to_telemetry_conversion:
                  enabled: true
                dimension_rollup_option: NoDimensionRollup
                metric_declarations:
                  - dimensions: [ [ ClusterName ], [ ClusterName, TaskDefinitionFamily ] ]
                    metric_name_selectors:
                      - MemoryUtilized
                      - MemoryReserved
                      - CpuUtilized
                      - CpuReserved
                      - NetworkRxBytes
                      - NetworkTxBytes
                      - StorageReadBytes
                      - StorageWriteBytes
                  - metric_name_selectors: [container.*]

            service:
              pipelines:
                traces:
                  receivers: [otlp,awsxray]
                  processors: [batch/traces]
                  exporters: [awsxray]
                metrics/application:
                  receivers: [otlp, statsd]
                  processors: [batch/metrics]
                  exporters: [awsemf/application]
                metrics/performance:
                  receivers: [awsecscontainermetrics ]
                  processors: [filter, metricstransform, resource]
                  exporters: [ awsemf/performance ]

              extensions: [health_check]
        EOT
      + key_id         = (known after apply)
      + name           = "/gyraffe/staging/worker/otel"
      + tags_all       = {
          + "environment" = "staging"
          + "project"     = "gyraffe"
        }
      + tier           = "Intelligent-Tiering"
      + type           = "String"
      + value          = (sensitive value)
      + version        = (known after apply)
    }

  # module.gyraffe.module.workers.module.task_security_group.aws_security_group.this_name_prefix[0] will be created
  + resource "aws_security_group" "this_name_prefix" {
      + arn                    = (known after apply)
      + description            = "Security Group managed by Terraform"
      + egress                 = (known after apply)
      + id                     = (known after apply)
      + ingress                = (known after apply)
      + name                   = (known after apply)
      + name_prefix            = "gyraffe-staging-worker-endpoint-"
      + owner_id               = (known after apply)
      + revoke_rules_on_delete = false
      + tags                   = {
          + "Name" = "gyraffe-staging-worker-endpoint"
        }
      + tags_all               = {
          + "Name"        = "gyraffe-staging-worker-endpoint"
          + "environment" = "staging"
          + "project"     = "gyraffe"
        }
      + vpc_id                 = "vpc-04840afb129303f79"

      + timeouts {
          + create = "10m"
          + delete = "15m"
        }
    }

  # module.gyraffe.module.workers.module.task_security_group.aws_security_group_rule.egress_rules[0] will be created
  + resource "aws_security_group_rule" "egress_rules" {
      + cidr_blocks              = [
          + "0.0.0.0/0",
        ]
      + description              = "All protocols"
      + from_port                = -1
      + id                       = (known after apply)
      + ipv6_cidr_blocks         = [
          + "::/0",
        ]
      + prefix_list_ids          = []
      + protocol                 = "-1"
      + security_group_id        = (known after apply)
      + security_group_rule_id   = (known after apply)
      + self                     = false
      + source_security_group_id = (known after apply)
      + to_port                  = -1
      + type                     = "egress"
    }

  # module.gyraffe.module.workers.module.task_security_group.aws_security_group_rule.ingress_with_source_security_group_id[0] will be created
  + resource "aws_security_group_rule" "ingress_with_source_security_group_id" {
      + description              = "worker access from the load balancer."
      + from_port                = 8080
      + id                       = (known after apply)
      + prefix_list_ids          = []
      + protocol                 = "tcp"
      + security_group_id        = (known after apply)
      + security_group_rule_id   = (known after apply)
      + self                     = false
      + source_security_group_id = (known after apply)
      + to_port                  = 8080
      + type                     = "ingress"
    }

  # module.gyraffe.module.workers.module.ecs_service.module.fargate.aws_ecs_service.main[0] will be created
  + resource "aws_ecs_service" "main" {
      + availability_zone_rebalancing      = "DISABLED"
      + cluster                            = (known after apply)
      + deployment_maximum_percent         = 200
      + deployment_minimum_healthy_percent = 100
      + desired_count                      = 1
      + enable_ecs_managed_tags            = false
      + enable_execute_command             = true
      + force_delete                       = false
      + health_check_grace_period_seconds  = 300
      + iam_role                           = (known after apply)
      + id                                 = (known after apply)
      + launch_type                        = "FARGATE"
      + name                               = "gyraffe-staging-worker"
      + platform_version                   = (known after apply)
      + scheduling_strategy                = "REPLICA"
      + tags_all                           = {
          + "environment" = "staging"
          + "project"     = "gyraffe"
        }
      + task_definition                    = (known after apply)
      + triggers                           = (known after apply)
      + wait_for_steady_state              = false

      + deployment_controller {
          + type = "ECS"
        }

      + network_configuration {
          + assign_public_ip = false
          + security_groups  = (known after apply)
          + subnets          = [
              + "subnet-010ebd9da41576f66",
              + "subnet-01952874853db1a0d",
              + "subnet-0305d4eece80ece12",
            ]
        }
    }

  # module.gyraffe.module.workers.module.ecs_service.module.fargate.module.task.aws_ecs_task_definition.main[0] will be created
  + resource "aws_ecs_task_definition" "main" {
      + arn                      = (known after apply)
      + arn_without_revision     = (known after apply)
      + container_definitions    = (known after apply)
      + cpu                      = "512"
      + enable_fault_injection   = false
      + execution_role_arn       = (known after apply)
      + family                   = "gyraffe-staging-worker"
      + id                       = (known after apply)
      + memory                   = "1024"
      + network_mode             = "awsvpc"
      + requires_compatibilities = [
          + "FARGATE",
        ]
      + revision                 = (known after apply)
      + skip_destroy             = false
      + tags_all                 = {
          + "environment" = "staging"
          + "project"     = "gyraffe"
        }
      + task_role_arn            = (known after apply)
      + track_latest             = false
    }

Plan: 21 to add, 1 to change, 0 to destroy.
```