### PR TITLE
fix prod gyraffe db access for data science

### DIFF
--- a/tofu/config/gyraffe.getyourrefund.org/main.tf
+++ b/tofu/config/gyraffe.getyourrefund.org/main.tf
@@ -36,4 +36,5 @@ module "gyraffe" {
 
   data_science_database_user = var.data_science_database_user
   data_science_databases = var.data_science_databases
+  additional_database_ingress = ["10.51.0.0/16"]
 }

--- a/tofu/modules/gyraffe/main.tf
+++ b/tofu/modules/gyraffe/main.tf
@@ -206,7 +206,7 @@ module "database" {
   secrets_key_arn    = module.secrets.kms_key_arn
   vpc_id             = module.vpc.vpc_id
   subnets            = module.vpc.private_subnets
-  ingress_cidrs      = module.vpc.private_subnets_cidr_blocks
+  ingress_cidrs      = concat(module.vpc.private_subnets_cidr_blocks, var.additional_database_ingress)
   iam_authentication = true
   enable_data_api    = true
   password_rotation_frequency = 90

--- a/tofu/modules/gyraffe/variables.tf
+++ b/tofu/modules/gyraffe/variables.tf
@@ -97,3 +97,9 @@ variable "data_science_databases" {
   description = "List of databases to grant data science read-only access to."
   default     = []
 }
+
+variable "additional_database_ingress" {
+  type        = list(string)
+  description = "List of additional CIDRs from which the database should permit ingress"
+  default     = []
+}


### PR DESCRIPTION
1. add a variable for additional database ingress cidrs, 
2. concatenate it onto the existing vpc private subnets for use, and 
3. provide the data science aptible vpc peer cidr so they can access the prod db

[staging plan](https://github.com/codeforamerica/tax-benefits-backend/actions/runs/24152902496/job/70484538088) (unrelated changes)
[prod plan](https://github.com/codeforamerica/tax-benefits-backend/actions/runs/24152923636/job/70484601501) (unrelated changes + the addition of the correct ingress cidr)