### PR TITLE
TEF-342: Define additional efiler api secrets and add them to environment secrets for web and worker

### DIFF
--- a/tofu/modules/gyraffe/main.tf
+++ b/tofu/modules/gyraffe/main.tf
@@ -132,6 +132,7 @@ module "web" {
     DATABASE_HOST     = module.database.cluster_endpoint
     REVIEW_APP        = var.review_app
     SCHEMA_S3_BUCKET  = module.schemas.bucket
+    SUBMISSION_BUNDLES_S3_BUCKET = module.submission_bundles.bucket
   }
   environment_secrets = {
     DATABASE_PASSWORD           = "${module.database.secret_arn}:password"

--- a/tofu/modules/gyraffe/main.tf
+++ b/tofu/modules/gyraffe/main.tf
@@ -53,6 +53,9 @@ module "secrets" {
     "SENTRY_DSN" = {
       description = "Data Source Name (DSN) for sentry integration"
     },
+    "EFILER_API_CLIENT_NAME" = {
+      description = "Name to use when making requests to efiler API"
+    },
     "EFILER_API_CLIENT_PRIVATE_KEY_BASE64" = {
       description = "Private key for signing requests to efiler API"
     }
@@ -136,6 +139,7 @@ module "web" {
     MAILGUN_DOMAIN              = module.secrets.secrets["MAILGUN_DOMAIN"].secret_arn
     MAILGUN_BASIC_AUTH_NAME     = module.secrets.secrets["MAILGUN_BASIC_AUTH_NAME"].secret_arn
     MAILGUN_BASIC_AUTH_PASSWORD = module.secrets.secrets["MAILGUN_BASIC_AUTH_PASSWORD"].secret_arn
+    EFILER_API_CLIENT_NAME      = module.secrets.secrets["EFILER_API_CLIENT_NAME"].secret_arn
     EFILER_API_CLIENT_PRIVATE_KEY_BASE64 = module.secrets.secrets["EFILER_API_CLIENT_PRIVATE_KEY_BASE64"].secret_arn
   }
 }
@@ -187,6 +191,7 @@ module "workers" {
     MAILGUN_DOMAIN              = module.secrets.secrets["MAILGUN_DOMAIN"].secret_arn
     MAILGUN_BASIC_AUTH_NAME     = module.secrets.secrets["MAILGUN_BASIC_AUTH_NAME"].secret_arn
     MAILGUN_BASIC_AUTH_PASSWORD = module.secrets.secrets["MAILGUN_BASIC_AUTH_PASSWORD"].secret_arn
+    EFILER_API_CLIENT_NAME      = module.secrets.secrets["EFILER_API_CLIENT_NAME"].secret_arn
     EFILER_API_CLIENT_PRIVATE_KEY_BASE64 = module.secrets.secrets["EFILER_API_CLIENT_PRIVATE_KEY_BASE64"].secret_arn
   }
 

--- a/tofu/modules/gyraffe/main.tf
+++ b/tofu/modules/gyraffe/main.tf
@@ -53,8 +53,11 @@ module "secrets" {
     "SENTRY_DSN" = {
       description = "Data Source Name (DSN) for sentry integration"
     },
-    "EFILER_API_HOST" = {
-      description = "Hostname for efiler API"
+    "BASE_URL" = {
+      description = "Base application URL"
+    },
+    "EFILER_API_URL" = {
+      description = "Base efiler API URL"
     },
     "EFILER_API_CLIENT_NAME" = {
       description = "Name to use when making requests to efiler API"
@@ -133,6 +136,7 @@ module "web" {
   environment_secrets = {
     DATABASE_PASSWORD           = "${module.database.secret_arn}:password"
     DATABASE_USER               = "${module.database.secret_arn}:username"
+    BASE_URL                    = module.secrets.secrets["BASE_URL"].secret_arn
     SECRET_KEY_BASE             = module.secrets.secrets["SECRET_KEY_BASE"].secret_arn
     SENTRY_DSN                  = module.secrets.secrets["SENTRY_DSN"].secret_arn
     TWILIO_ACCOUNT_SID          = module.secrets.secrets["TWILIO_ACCOUNT_SID"].secret_arn
@@ -142,7 +146,7 @@ module "web" {
     MAILGUN_DOMAIN              = module.secrets.secrets["MAILGUN_DOMAIN"].secret_arn
     MAILGUN_BASIC_AUTH_NAME     = module.secrets.secrets["MAILGUN_BASIC_AUTH_NAME"].secret_arn
     MAILGUN_BASIC_AUTH_PASSWORD = module.secrets.secrets["MAILGUN_BASIC_AUTH_PASSWORD"].secret_arn
-    EFILER_API_HOST             = module.secrets.secrets["EFILER_API_HOST"].secret_arn
+    EFILER_API_URL              = module.secrets.secrets["EFILER_API_URL"].secret_arn
     EFILER_API_CLIENT_NAME      = module.secrets.secrets["EFILER_API_CLIENT_NAME"].secret_arn
     EFILER_API_CLIENT_PRIVATE_KEY_BASE64 = module.secrets.secrets["EFILER_API_CLIENT_PRIVATE_KEY_BASE64"].secret_arn
   }
@@ -186,6 +190,7 @@ module "workers" {
   environment_secrets = {
     DATABASE_PASSWORD           = "${module.database.secret_arn}:password"
     DATABASE_USER               = "${module.database.secret_arn}:username"
+    BASE_URL                    = module.secrets.secrets["BASE_URL"].secret_arn
     SECRET_KEY_BASE             = module.secrets.secrets["SECRET_KEY_BASE"].secret_arn
     SENTRY_DSN                  = module.secrets.secrets["SENTRY_DSN"].secret_arn
     TWILIO_ACCOUNT_SID          = module.secrets.secrets["TWILIO_ACCOUNT_SID"].secret_arn
@@ -195,7 +200,7 @@ module "workers" {
     MAILGUN_DOMAIN              = module.secrets.secrets["MAILGUN_DOMAIN"].secret_arn
     MAILGUN_BASIC_AUTH_NAME     = module.secrets.secrets["MAILGUN_BASIC_AUTH_NAME"].secret_arn
     MAILGUN_BASIC_AUTH_PASSWORD = module.secrets.secrets["MAILGUN_BASIC_AUTH_PASSWORD"].secret_arn
-    EFILER_API_HOST             = module.secrets.secrets["EFILER_API_HOST"].secret_arn
+    EFILER_API_URL              = module.secrets.secrets["EFILER_API_URL"].secret_arn
     EFILER_API_CLIENT_NAME      = module.secrets.secrets["EFILER_API_CLIENT_NAME"].secret_arn
     EFILER_API_CLIENT_PRIVATE_KEY_BASE64 = module.secrets.secrets["EFILER_API_CLIENT_PRIVATE_KEY_BASE64"].secret_arn
   }

--- a/tofu/modules/gyraffe/main.tf
+++ b/tofu/modules/gyraffe/main.tf
@@ -187,6 +187,7 @@ module "workers" {
     DATABASE_HOST     = module.database.cluster_endpoint
     REVIEW_APP        = var.review_app
     SCHEMA_S3_BUCKET  = module.schemas.bucket
+    SUBMISSION_BUNDLES_S3_BUCKET = module.submission_bundles.bucket
   }
   environment_secrets = {
     DATABASE_PASSWORD           = "${module.database.secret_arn}:password"

--- a/tofu/modules/gyraffe/main.tf
+++ b/tofu/modules/gyraffe/main.tf
@@ -53,6 +53,9 @@ module "secrets" {
     "SENTRY_DSN" = {
       description = "Data Source Name (DSN) for sentry integration"
     },
+    "EFILER_API_HOST" = {
+      description = "Hostname for efiler API"
+    },
     "EFILER_API_CLIENT_NAME" = {
       description = "Name to use when making requests to efiler API"
     },
@@ -139,6 +142,7 @@ module "web" {
     MAILGUN_DOMAIN              = module.secrets.secrets["MAILGUN_DOMAIN"].secret_arn
     MAILGUN_BASIC_AUTH_NAME     = module.secrets.secrets["MAILGUN_BASIC_AUTH_NAME"].secret_arn
     MAILGUN_BASIC_AUTH_PASSWORD = module.secrets.secrets["MAILGUN_BASIC_AUTH_PASSWORD"].secret_arn
+    EFILER_API_HOST             = module.secrets.secrets["EFILER_API_HOST"].secret_arn
     EFILER_API_CLIENT_NAME      = module.secrets.secrets["EFILER_API_CLIENT_NAME"].secret_arn
     EFILER_API_CLIENT_PRIVATE_KEY_BASE64 = module.secrets.secrets["EFILER_API_CLIENT_PRIVATE_KEY_BASE64"].secret_arn
   }
@@ -191,6 +195,7 @@ module "workers" {
     MAILGUN_DOMAIN              = module.secrets.secrets["MAILGUN_DOMAIN"].secret_arn
     MAILGUN_BASIC_AUTH_NAME     = module.secrets.secrets["MAILGUN_BASIC_AUTH_NAME"].secret_arn
     MAILGUN_BASIC_AUTH_PASSWORD = module.secrets.secrets["MAILGUN_BASIC_AUTH_PASSWORD"].secret_arn
+    EFILER_API_HOST             = module.secrets.secrets["EFILER_API_HOST"].secret_arn
     EFILER_API_CLIENT_NAME      = module.secrets.secrets["EFILER_API_CLIENT_NAME"].secret_arn
     EFILER_API_CLIENT_PRIVATE_KEY_BASE64 = module.secrets.secrets["EFILER_API_CLIENT_PRIVATE_KEY_BASE64"].secret_arn
   }


### PR DESCRIPTION
These will have their values set in Doppler, so deployment will require the following flow:
1. Deploy infrastructure (which will create the secrets in AWS Secrets Manager)
2. Create identically-named Doppler secrets & give them appropriate values before saving/syncing
3. Sync from Doppler -> AWS Secrets Manager
4. Redeploy infrastructure to pick up new secret values as env variables