### PR TITLE
TEF-343: add submissions status and acks callback paths to webhooks bypass

### DIFF
--- a/tofu/modules/gyraffe/main.tf
+++ b/tofu/modules/gyraffe/main.tf
@@ -409,6 +409,8 @@ module "cloudfront_waf" {
     efiler_api_callback = {
       paths = [
         { constraint = "EXACTLY", path = "/efiler-api/submit-callback" },
+        { constraint = "EXACTLY", path = "/efiler-api/submissions-status-callback" },
+        { constraint = "EXACTLY", path = "/efiler-api/acks-callback" },
       ]
       criteria = []
       action   = "allow"


### PR DESCRIPTION
https://codeforamerica.atlassian.net/browse/TEF-343

[staging plan](https://github.com/codeforamerica/tax-benefits-backend/actions/runs/25084014888/job/73495360076)

[prod plan](https://github.com/codeforamerica/tax-benefits-backend/actions/runs/25085184099/job/73499041911)

Corresponds to https://github.com/codeforamerica/gyraffe/pull/386