### PR TITLE
TEF-615 authenticate efiler api callbacks

### DIFF
--- a/tofu/modules/efiler_api/main.tf
+++ b/tofu/modules/efiler_api/main.tf
@@ -5,6 +5,9 @@ locals {
       start_value = jsonencode({
         key = ""
       })
+    },
+    "efiler_api_callback_secret" = {
+      description = "Shared secret for authenticating EFiler API callbacks"
     }
   }
 
@@ -26,6 +29,7 @@ locals {
     DATABASE_PASSWORD = "${module.database.secret_arn}:password"
     DATABASE_USER     = "${module.database.secret_arn}:username"
     SECRET_KEY_BASE   = "${module.secrets.secrets["rails_secret_key_base"].secret_arn}:key"
+    EFILER_API_CALLBACK_SECRET = module.secrets.secrets["efiler_api_callback_secret"].secret_arn
   }
 
   api_client_secret_names = {

--- a/tofu/modules/gyraffe/main.tf
+++ b/tofu/modules/gyraffe/main.tf
@@ -82,6 +82,9 @@ module "secrets" {
     },
     "INTERCOM_SECURE_MODE_SECRET_KEY" = {
       description = "Intercom secure mode secret key"
+    },
+    "EFILER_API_CALLBACK_SECRET" = {
+      description = "Shared secret for authenticating EFiler API callbacks"
     }
   }
 }
@@ -174,6 +177,7 @@ module "web" {
     MIXPANEL_TOKEN              = module.secrets.secrets["MIXPANEL_TOKEN"].secret_arn
     INTERCOM_APP_ID                 = module.secrets.secrets["INTERCOM_APP_ID"].secret_arn
     INTERCOM_SECURE_MODE_SECRET_KEY = module.secrets.secrets["INTERCOM_SECURE_MODE_SECRET_KEY"].secret_arn
+    EFILER_API_CALLBACK_SECRET = module.secrets.secrets["EFILER_API_CALLBACK_SECRET"].secret_arn
   }
 }
 
@@ -235,6 +239,7 @@ module "workers" {
     MIXPANEL_TOKEN              = module.secrets.secrets["MIXPANEL_TOKEN"].secret_arn
     INTERCOM_APP_ID                 = module.secrets.secrets["INTERCOM_APP_ID"].secret_arn
     INTERCOM_SECURE_MODE_SECRET_KEY = module.secrets.secrets["INTERCOM_SECURE_MODE_SECRET_KEY"].secret_arn
+    EFILER_API_CALLBACK_SECRET = module.secrets.secrets["EFILER_API_CALLBACK_SECRET"].secret_arn
   }
 
   container_command = ["bin/jobs"]

--- a/tofu/modules/gyraffe/main.tf
+++ b/tofu/modules/gyraffe/main.tf
@@ -418,10 +418,9 @@ module "cloudfront_waf" {
   } : {}
 
   # EFiler API submit callbacks contain XML in a JSON `result` field, which
-  # trips CrossSiteScripting_BODY in the AWS managed CommonRuleSet. Allow the
-  # callback path through the WAF until callbacks are signed, at which point
-  # this can be tightened with a header criteria.
-  # TODO(TEF-615) - Add header criteria & change this comment
+  # trips CrossSiteScripting_BODY in the AWS managed CommonRuleSet. Allow
+  # requests to the callback paths through the WAF, but only when the
+  # X-EFiler-Callback-Secret header set by EFiler API is present
   webhooks = {
     efiler_api_callback = {
       paths = [
@@ -429,8 +428,16 @@ module "cloudfront_waf" {
         { constraint = "EXACTLY", path = "/efiler-api/submissions-status-callback" },
         { constraint = "EXACTLY", path = "/efiler-api/acks-callback" },
       ]
-      criteria = []
-      action   = "allow"
+      criteria = [
+        {
+          type       = "size"
+          constraint = "GT"
+          field      = "header"
+          name       = "x-efiler-callback-secret"
+          value      = "0"
+        }
+      ]
+      action = "allow"
     }
   }
 }


### PR DESCRIPTION
https://codeforamerica.atlassian.net/browse/TEF-615

This supports a change where EFiler API will authenticate with callback endpoints in SimpleFile by adding a shared secret in the request headers.

This adds an environment variable `EFILER_API_CALLBACK_SECRET` to the EFiler API and SimpleFile repositories. We'll still need to set its value in Doppler (for SimpleFile) and AWS Secrets Manager (for EFiler API, if I understand correctly).

Also, this rejects requests to SimpleFile's callback endpoints if the shared secret header is missing. (only allow the request if the size of that header is greater than zero).